### PR TITLE
add terminal-themed animations and rename Technologies to Tags

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -101,6 +101,11 @@
   animation: glow 2s ease-in-out infinite;
 }
 
+.text-glow-bright {
+  text-shadow: 0 0 12px color-mix(in srgb, var(--t-glow) 90%, transparent), 0 0 24px color-mix(in srgb, var(--t-glow) 50%, transparent);
+  transition: text-shadow 0.3s ease-out;
+}
+
 /* CRT flicker */
 @keyframes flicker {
   0% { opacity: 0.97; }
@@ -146,5 +151,9 @@ body::before {
 
   .text-glow {
     animation: none;
+  }
+
+  .text-glow-bright {
+    text-shadow: none;
   }
 }

--- a/src/components/pages/about-me-page.tsx
+++ b/src/components/pages/about-me-page.tsx
@@ -1,34 +1,102 @@
 "use client"
 
-import React from "react";
+import React, { useState, useEffect, useRef } from "react";
 import Link from "next/link";
+import { motion, useReducedMotion } from "framer-motion";
 import { TerminalPage } from "@/components/terminal-page";
 import { PROFILE_FIELDS, BIO_TEXT, ASCII_JAMES, ASCII_GRAY } from "@/data/content";
 
+function useScanlineReveal(lines: string[], speed = 80) {
+  const [revealed, setRevealed] = useState(0);
+  const prefersReduced = useRef(false);
+
+  useEffect(() => {
+    prefersReduced.current = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    if (prefersReduced.current) {
+      setRevealed(lines.length);
+      return;
+    }
+
+    setRevealed(0);
+    let i = 0;
+    const interval = setInterval(() => {
+      i++;
+      setRevealed(i);
+      if (i >= lines.length) clearInterval(interval);
+    }, speed);
+
+    return () => clearInterval(interval);
+  }, [lines.length, speed]);
+
+  return { revealed, done: revealed >= lines.length };
+}
+
+const profileVariants = {
+  hidden: {},
+  visible: { transition: { staggerChildren: 0.06 } },
+};
+
+const profileItemVariants = {
+  hidden: { opacity: 0, x: -8 },
+  visible: { opacity: 1, x: 0, transition: { duration: 0.25 } },
+};
+
 export const AboutMePage: React.FC = () => {
+  const jamesLines = ASCII_JAMES.split("\n");
+  const grayLines = ASCII_GRAY.split("\n");
+  const allLines = [...jamesLines, ...grayLines];
+  const { revealed, done } = useScanlineReveal(allLines);
+  const reduceMotion = useReducedMotion();
+
   return (
     <TerminalPage command="neofetch" showSearch={false}>
       {() => (
         <div className="flex flex-col lg:flex-row gap-6 w-full h-full items-center justify-center">
           <div className="shrink-0 overflow-x-auto max-w-[50%] lg:max-w-none">
             <pre className="text-terminal-green text-glow text-[0.35rem] sm:text-[0.5rem] lg:text-xs leading-tight whitespace-pre">
-              {ASCII_JAMES}
+              {jamesLines.map((line, i) => (
+                <div
+                  key={i}
+                  className={`transition-opacity duration-300 ${
+                    i < revealed ? "opacity-100" : "opacity-0"
+                  } ${i === revealed - 1 && !done ? "text-glow-bright" : ""}`}
+                >
+                  {line}
+                </div>
+              ))}
             </pre>
             <pre className="text-terminal-cyan text-glow text-[0.35rem] sm:text-[0.5rem] lg:text-xs leading-tight whitespace-pre mt-1">
-              {ASCII_GRAY}
+              {grayLines.map((line, i) => {
+                const globalIndex = jamesLines.length + i;
+                return (
+                  <div
+                    key={i}
+                    className={`transition-opacity duration-300 ${
+                      globalIndex < revealed ? "opacity-100" : "opacity-0"
+                    } ${globalIndex === revealed - 1 && !done ? "text-glow-bright" : ""}`}
+                  >
+                    {line}
+                  </div>
+                );
+              })}
             </pre>
           </div>
 
-          <div className="text-xs md:text-sm space-y-1 min-w-0">
-            <div className="mb-2">
+          <motion.div
+            className="text-xs md:text-sm space-y-1 min-w-0"
+            variants={profileVariants}
+            initial={reduceMotion ? false : "hidden"}
+            animate={done ? "visible" : "hidden"}
+          >
+            <motion.div className="mb-2" variants={profileItemVariants}>
               <span className="text-terminal-cyan font-bold">james</span>
               <span className="text-terminal-dim">@</span>
               <span className="text-terminal-cyan font-bold">portfolio</span>
-            </div>
-            <div className="border-b border-terminal-border mb-2 w-full"></div>
+            </motion.div>
+            <motion.div className="border-b border-terminal-border mb-2 w-full" variants={profileItemVariants} />
 
             {PROFILE_FIELDS.map((field, i) => (
-              <div key={i} className="flex flex-wrap gap-1">
+              <motion.div key={i} className="flex flex-wrap gap-1" variants={profileItemVariants}>
                 <span className="text-terminal-amber font-bold">{field.key}:</span>
                 {field.url ? (
                   <Link
@@ -42,20 +110,20 @@ export const AboutMePage: React.FC = () => {
                 ) : (
                   <span className="text-terminal-dim">{field.value}</span>
                 )}
-              </div>
+              </motion.div>
             ))}
 
-            <div className="border-b border-terminal-border my-2 w-full"></div>
-            <div className="text-terminal-dim leading-relaxed">
+            <motion.div className="border-b border-terminal-border my-2 w-full" variants={profileItemVariants} />
+            <motion.div className="text-terminal-dim leading-relaxed" variants={profileItemVariants}>
               {BIO_TEXT}
-            </div>
+            </motion.div>
 
-            <div className="flex gap-0.5 mt-3" aria-hidden="true">
+            <motion.div className="flex gap-0.5 mt-3" aria-hidden="true" variants={profileItemVariants}>
               {["bg-terminal-red", "bg-terminal-green", "bg-terminal-amber", "bg-terminal-cyan", "bg-terminal-dim", "bg-terminal-border", "bg-terminal-bg-light", "bg-terminal-bg"].map((color, i) => (
                 <div key={i} className={`w-4 h-4 md:w-5 md:h-5 ${color}`}></div>
               ))}
-            </div>
-          </div>
+            </motion.div>
+          </motion.div>
         </div>
       )}
     </TerminalPage>

--- a/src/components/pages/contact-page.tsx
+++ b/src/components/pages/contact-page.tsx
@@ -2,6 +2,7 @@
 
 import React from "react";
 import Link from "next/link";
+import { motion, useReducedMotion } from "framer-motion";
 import { FiMail, FiGithub, FiLinkedin } from "react-icons/fi";
 import { CONTACT_FIELDS, ProfileField, filterContact } from "@/data/content";
 import { TerminalPage } from "@/components/terminal-page";
@@ -40,6 +41,7 @@ function ContactCard({ field }: { field: ProfileField }) {
 }
 
 export const ContactPage: React.FC = () => {
+  const reduceMotion = useReducedMotion();
   return (
     <TerminalPage
       command="cat ~/contacts"
@@ -56,11 +58,21 @@ export const ContactPage: React.FC = () => {
         const filtered = CONTACT_FIELDS.filter((f) => !q || filterContact(f, q));
 
         return (
-          <div className="grid gap-3 w-full">
+          <motion.div
+            className="grid gap-3 w-full"
+            initial={reduceMotion ? false : "hidden"}
+            animate="visible"
+            variants={{ hidden: {}, visible: { transition: { staggerChildren: 0.05 } } }}
+          >
             {filtered.map((field, i) => (
-              <ContactCard key={i} field={field} />
+              <motion.div
+                key={i}
+                variants={{ hidden: { opacity: 0, y: 8 }, visible: { opacity: 1, y: 0, transition: { duration: 0.2 } } }}
+              >
+                <ContactCard field={field} />
+              </motion.div>
             ))}
-          </div>
+          </motion.div>
         );
       }}
     </TerminalPage>

--- a/src/components/pages/experience-page.tsx
+++ b/src/components/pages/experience-page.tsx
@@ -52,7 +52,7 @@ export const ExperiencePage: React.FC = () => {
               content: <BulletList items={exp.details} />,
             }] : []),
             ...(exp.tags.length > 0 ? [{
-              heading: "Technologies",
+              heading: "Tags",
               content: <BadgeList items={exp.tags} />,
             }] : []),
           ] : []}

--- a/src/components/pages/projects-page.tsx
+++ b/src/components/pages/projects-page.tsx
@@ -18,8 +18,11 @@ export const ProjectsPage: React.FC = () => {
       renderItem={(p, onClick) => (
         <button
           onClick={onClick}
-          className="block w-full text-left px-4 py-3 rounded-sm transition-colors hover:bg-terminal-green/5 group border border-terminal-border hover:border-terminal-green/40 bg-terminal-bg"
+          className="relative block w-full text-left pl-7 pr-4 py-3 rounded-sm transition-all hover:bg-terminal-green/5 group border border-terminal-border hover:border-terminal-green/60 hover:shadow-[inset_2px_0_0_var(--t-green)] bg-terminal-bg"
         >
+          <span className="absolute left-2 top-1/2 -translate-y-1/2 text-terminal-green font-bold opacity-0 -translate-x-2 group-hover:opacity-100 group-hover:translate-x-0 transition-all duration-150 motion-reduce:transition-none">
+            &gt;
+          </span>
           <div className="flex items-center gap-2 mb-1">
             <span className="text-terminal-green font-bold text-sm md:text-base flex items-center gap-1 group-hover:underline">
               {p.dir}/
@@ -49,7 +52,7 @@ export const ProjectsPage: React.FC = () => {
               content: <BulletList items={project.details} />,
             }] : []),
             {
-              heading: "Technologies",
+              heading: "Tags",
               content: <BadgeList items={project.tags} />,
             },
             ...(project.url ? [{

--- a/src/components/terminal-page.tsx
+++ b/src/components/terminal-page.tsx
@@ -1,13 +1,58 @@
 "use client"
 
-import React, { useState, useRef } from "react";
+import React, { useState, useRef, useEffect } from "react";
 import { FiSearch } from "react-icons/fi";
+
+function useTypewriter(text: string, speed = 30) {
+  const [length, setLength] = useState(0);
+  const [showCursor, setShowCursor] = useState(true);
+  const prefersReduced = useRef(false);
+
+  useEffect(() => {
+    prefersReduced.current = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  }, []);
+
+  useEffect(() => {
+    if (prefersReduced.current) {
+      setLength(text.length);
+      setShowCursor(false);
+      return;
+    }
+
+    setLength(0);
+    setShowCursor(true);
+
+    let i = 0;
+    const interval = setInterval(() => {
+      i++;
+      setLength(i);
+      if (i >= text.length) {
+        clearInterval(interval);
+        setTimeout(() => setShowCursor(false), 1500);
+      }
+    }, speed);
+
+    return () => clearInterval(interval);
+  }, [text, speed]);
+
+  return { displayed: text.slice(0, length), showCursor, done: length >= text.length };
+}
 
 interface TerminalPageProps {
   command: string;
   footer?: React.ReactNode | ((search: string) => React.ReactNode);
   showSearch?: boolean;
   children: (search: string) => React.ReactNode;
+}
+
+function TypewriterCommand({ command }: { command: string }) {
+  const { displayed, showCursor } = useTypewriter(command);
+  return (
+    <>
+      {displayed}
+      {showCursor && <span className="animate-blink">_</span>}
+    </>
+  );
 }
 
 export const TerminalPage: React.FC<TerminalPageProps> = ({ command, footer, showSearch = true, children }) => {
@@ -22,7 +67,7 @@ export const TerminalPage: React.FC<TerminalPageProps> = ({ command, footer, sho
     <div className="flex flex-col h-full">
       <div className="shrink-0 flex items-center justify-between gap-2 mb-4">
         <div className="text-terminal-green text-xs md:text-sm min-w-0 truncate">
-          $ {command}
+          $ <TypewriterCommand command={command} />
         </div>
         {showSearch && (
           <div

--- a/src/components/timeline-list.tsx
+++ b/src/components/timeline-list.tsx
@@ -1,6 +1,7 @@
 "use client"
 
-import React, { useState } from "react";
+import React, { useState, useRef, useCallback, useEffect } from "react";
+import { motion, useReducedMotion } from "framer-motion";
 import { TerminalPage } from "@/components/terminal-page";
 
 interface TimelineListProps<T> {
@@ -14,9 +15,63 @@ interface TimelineListProps<T> {
   renderFooter: (filtered: number, total: number) => React.ReactNode;
 }
 
+const containerVariants = {
+  hidden: {},
+  visible: { transition: { staggerChildren: 0.05 } },
+};
+
+const itemVariants = {
+  hidden: { opacity: 0, y: 8 },
+  visible: { opacity: 1, y: 0, transition: { duration: 0.2 } },
+};
+
 export function TimelineList<T>({ command, items, getKey, filterFn, renderEntry, renderItem, renderModal, renderFooter }: TimelineListProps<T>) {
   const [selectedKey, setSelectedKey] = useState<string | null>(null);
+  const [activeIndex, setActiveIndex] = useState<number | null>(null);
   const selectedItem = selectedKey !== null ? items.find((item) => getKey(item) === selectedKey) ?? null : null;
+  const reduceMotion = useReducedMotion();
+
+  const dotRefs = useRef<Map<number, HTMLDivElement>>(new Map());
+  const containerRef = useRef<HTMLDivElement>(null);
+  const rafRef = useRef<number | null>(null);
+
+  const setDotRef = useCallback((index: number, el: HTMLDivElement | null) => {
+    if (el) dotRefs.current.set(index, el);
+    else dotRefs.current.delete(index);
+  }, []);
+
+  const handleMouseMove = useCallback((e: React.MouseEvent) => {
+    if (rafRef.current) return;
+    rafRef.current = requestAnimationFrame(() => {
+      rafRef.current = null;
+      const mouseY = e.clientY;
+      let closest = -1;
+      let minDist = Infinity;
+      dotRefs.current.forEach((el, idx) => {
+        const rect = el.getBoundingClientRect();
+        const dist = Math.abs(rect.top + rect.height / 2 - mouseY);
+        if (dist < minDist) {
+          minDist = dist;
+          closest = idx;
+        }
+      });
+      setActiveIndex(closest >= 0 ? closest : null);
+    });
+  }, []);
+
+  const handleMouseLeave = useCallback(() => {
+    if (rafRef.current) {
+      cancelAnimationFrame(rafRef.current);
+      rafRef.current = null;
+    }
+    setActiveIndex(null);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+    };
+  }, []);
 
   const filterItems = (search: string) => {
     const q = search.toLowerCase();
@@ -36,33 +91,60 @@ export function TimelineList<T>({ command, items, getKey, filterFn, renderEntry,
 
         return (
           <>
-            <div className={`w-full text-xs md:text-sm ${renderItem ? "space-y-2" : ""}`}>
+            <motion.div
+              className={`w-full text-xs md:text-sm ${renderItem ? "space-y-2" : "pl-1"}`}
+              ref={containerRef}
+              onMouseMove={!renderItem ? handleMouseMove : undefined}
+              onMouseLeave={!renderItem ? handleMouseLeave : undefined}
+              variants={containerVariants}
+              initial={reduceMotion ? false : "hidden"}
+              animate="visible"
+            >
               {filtered.map((item, index) => {
                 const key = getKey(item);
 
                 if (renderItem) {
-                  return <React.Fragment key={key}>{renderItem(item, () => setSelectedKey(key))}</React.Fragment>;
+                  return (
+                    <motion.div key={key} variants={itemVariants}>
+                      {renderItem(item, () => setSelectedKey(key))}
+                    </motion.div>
+                  );
                 }
 
                 const isLast = index === filtered.length - 1;
+                const isActive = activeIndex === index;
                 return (
-                  <button
+                  <motion.button
                     key={key}
+                    variants={itemVariants}
                     onClick={() => setSelectedKey(key)}
                     className="flex w-full text-left group cursor-pointer"
                   >
-                    <div className="flex flex-col items-center mr-4 shrink-0">
-                      <div className="w-3 h-3 rounded-full bg-terminal-green border-2 border-terminal-dim mt-1 group-hover:border-terminal-green transition-colors"></div>
-                      {!isLast && <div className="w-0.5 flex-1 bg-terminal-dim"></div>}
+                    <div className="flex flex-col items-center mr-4 shrink-0 overflow-visible">
+                      <div
+                        ref={(el) => setDotRef(index, el)}
+                        className={`w-3 h-3 rounded-full bg-terminal-green border-2 mt-1 transition-all duration-200 ${
+                          isActive
+                            ? "border-terminal-green scale-[1.3] shadow-[0_0_8px_var(--t-glow)]"
+                            : "border-terminal-dim group-hover:border-terminal-green"
+                        }`}
+                      />
+                      {!isLast && (
+                        <div className={`w-0.5 flex-1 transition-colors duration-200 ${
+                          isActive ? "bg-terminal-green" : "bg-terminal-dim"
+                        }`} />
+                      )}
                     </div>
 
-                    <div className="pb-6 flex-1 min-w-0">
+                    <div className={`pb-6 flex-1 min-w-0 transition-opacity duration-200 ${
+                      isActive ? "opacity-100" : activeIndex !== null ? "opacity-60" : ""
+                    }`}>
                       {renderEntry(item)}
                     </div>
-                  </button>
+                  </motion.button>
                 );
               })}
-            </div>
+            </motion.div>
 
             {renderModal(selectedItem, () => setSelectedKey(null))}
           </>


### PR DESCRIPTION
- Typewriter effect on command line when switching tabs
- Staggered entry reveal on timeline, project, and contact pages
- Mouse-proximity highlighting on git graph timeline dots
- ASCII art scanline reveal on about page with profile field stagger
- Project card '>' cursor hover effect with left-edge glow
- Fix timeline dot glow clipping on hover
- All animations respect prefers-reduced-motion
- Rename "Technologies" heading to "Tags" in modals