### PR TITLE
feat: contact redesign, animated git-log timeline, themed 404

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,32 @@
+import Link from "next/link";
+
+const ASCII_404 = `██╗  ██╗ ██████╗ ██╗  ██╗
+██║  ██║██╔═████╗██║  ██║
+███████║██║██╔██║███████║
+╚════██║████╔╝██║╚════██║
+     ██║╚██████╔╝     ██║
+     ╚═╝ ╚═════╝      ╚═╝`;
+
+export default function NotFound() {
+  return (
+    <main className="flex min-h-dvh flex-col items-center justify-center gap-5 px-6 pt-[38px] text-center font-mono">
+      <pre className="text-terminal-green text-glow text-[0.55rem] sm:text-xs leading-tight whitespace-pre">
+        {ASCII_404}
+      </pre>
+
+      <div className="space-y-1">
+        <p className="t-body font-bold text-terminal-red">segmentation fault (core dumped)</p>
+        <p className="t-body text-terminal-dim">
+          <span className="text-terminal-green">$</span> cat that-page &mdash; no such file or directory
+        </p>
+      </div>
+
+      <Link
+        href="/"
+        className="rounded-sm border border-terminal-green px-4 py-1.5 t-body font-bold text-terminal-green transition-colors hover:bg-terminal-green/10"
+      >
+        cd ~ &nbsp;<span className="text-terminal-dim">(return home)</span>
+      </Link>
+    </main>
+  );
+}

--- a/src/components/pages/about-me-page.tsx
+++ b/src/components/pages/about-me-page.tsx
@@ -10,13 +10,13 @@ import { motion, useReducedMotion } from "framer-motion";
 import { TerminalPage } from "@/components/terminal-page";
 import { PROFILE_FIELDS, BIO_TEXT, ASCII_JAMES, ASCII_GRAY } from "@/data/content";
 
-function useScanlineReveal(lines: string[], speed = 80) {
+function useScanlineReveal(lines: string[], speed = 90) {
   const { count, done } = useRevealCount(lines.length, speed);
   return { revealed: count, done };
 }
 
 const profileVariants = staggerContainer(0.06);
-const profileItemVariants = fadeIn({ x: -8, duration: 0.25 });
+const profileItemVariants = fadeIn({ x: -8 });
 
 // Neofetch-style palette strip, derived from the terminal tokens.
 const SWATCH_TOKENS = ["red", "green", "amber", "cyan", "dim", "border", "bg-light", "bg"] as const;

--- a/src/components/pages/contact-page.tsx
+++ b/src/components/pages/contact-page.tsx
@@ -1,341 +1,260 @@
 "use client"
 
-import React, { useState, useEffect, useRef, useMemo, useCallback } from "react";
+import React, { useState, useEffect, useCallback } from "react";
 import { motion, useReducedMotion } from "framer-motion";
-import { FiMail, FiGithub, FiLinkedin, FiMessageCircle, FiGlobe } from "react-icons/fi";
-import { CONTACT_FIELDS, ProfileField, filterContact } from "@/data/content";
+import { FiMail, FiGithub, FiLinkedin, FiCopy, FiCheck, FiExternalLink, FiSend } from "react-icons/fi";
+import { CONTACT_FIELDS, ProfileField } from "@/data/content";
 import { TerminalPage } from "@/components/terminal-page";
-import { terminalColors as T } from "@/lib/tokens";
+import { ExternalLink } from "@/components/external-link";
+import { staggerContainer, fadeIn } from "@/lib/motion";
+import { cn } from "@/lib/utils";
 
-const ICON_MAP: Record<string, React.ComponentType<{ className?: string; style?: React.CSSProperties }>> = {
+const ICON_MAP: Record<string, React.ComponentType<{ className?: string }>> = {
   EMAIL: FiMail,
   LINKEDIN: FiLinkedin,
   GITHUB: FiGithub,
 };
 
-const FALLBACK_ICON = FiGlobe;
+const EMAIL = CONTACT_FIELDS.find((f) => f.key === "EMAIL")?.value ?? "";
+const DEFAULT_SUBJECT = "Hello from your portfolio";
 
-function useContainerSize(ref: React.RefObject<HTMLDivElement | null>) {
-  const [size, setSize] = useState({ width: 0, height: 0 });
-  useEffect(() => {
-    const el = ref.current;
-    if (!el) return;
-    const observer = new ResizeObserver(([entry]) => {
-      setSize({
-        width: entry.contentRect.width,
-        height: entry.contentRect.height,
-      });
-    });
-    observer.observe(el);
-    return () => observer.disconnect();
-  }, [ref]);
-  return size;
-}
+const colVariants = staggerContainer();
+// Opacity-only fade: a vertical translate would briefly push the full-height
+// grid past the scroll area on mount, flashing a scrollbar before it settles.
+const itemVariants = fadeIn();
 
-function useGraphLayout(width: number, height: number) {
-  return useMemo(() => {
-    const minDim = Math.min(width, height);
-    const cx = width / 2;
-    const cy = height / 2;
-    const radius = minDim * 0.3;
-    const nodeR = minDim * 0.065;
-    const hubR = minDim * 0.085;
-    const labelSize = Math.min(16, Math.max(14, minDim * 0.035));
-    const valueSize = Math.min(14, Math.max(12, minDim * 0.03));
-    const hubLabelSize = Math.min(16, Math.max(14, minDim * 0.035));
-    const iconSize = nodeR * 0.75;
-    const hubIconSize = hubR * 0.7;
-    const strokeBase = Math.max(0.5, minDim * 0.002);
-    const dashArray = `${minDim * 0.01} ${minDim * 0.0075}`;
-    const packetR = minDim * 0.005;
-
-    return {
-      cx, cy, radius, nodeR, hubR,
-      labelSize, valueSize, hubLabelSize,
-      iconSize, hubIconSize,
-      strokeBase, dashArray, packetR,
-    };
-  }, [width, height]);
-}
-
-function getNodePositions(count: number, cx: number, cy: number, radius: number) {
-  return Array.from({ length: count }, (_, i) => {
-    const angle = (i * 2 * Math.PI) / count - Math.PI / 2;
-    return {
-      x: cx + radius * Math.cos(angle),
-      y: cy + radius * Math.sin(angle),
-    };
-  });
-}
-
-function ContactGraph({ fields }: { fields: ProfileField[] }) {
-  const containerRef = useRef<HTMLDivElement>(null);
-  const { width, height } = useContainerSize(containerRef);
-  const [hovered, setHovered] = useState<number | null>(null);
+function useCopy(value: string) {
   const [copied, setCopied] = useState(false);
-  const reduceMotion = useReducedMotion();
+  const copy = useCallback(() => {
+    navigator.clipboard
+      ?.writeText(value)
+      .then(() => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 1500);
+      })
+      .catch(() => {
+        /* clipboard unavailable — no-op */
+      });
+  }, [value]);
+  return { copied, copy };
+}
 
-  const handleCopyEmail = useCallback((value: string) => {
-    navigator.clipboard.writeText(value).then(() => {
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    }).catch(() => {
-      // Clipboard unavailable (insecure context or permission denied) — skip feedback.
-    });
+/** Live "available for work" status with the owner's local time. */
+function StatusLine() {
+  const reduce = useReducedMotion();
+  const [time, setTime] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fmt = () =>
+      new Intl.DateTimeFormat("en-GB", {
+        hour: "2-digit",
+        minute: "2-digit",
+        timeZone: "Europe/London",
+        timeZoneName: "short",
+      }).format(new Date());
+    setTime(fmt());
+    const id = setInterval(() => setTime(fmt()), 20_000);
+    return () => clearInterval(id);
   }, []);
 
-  const layout = useGraphLayout(width, height);
-  const {
-    cx, cy, radius, nodeR, hubR,
-    labelSize, valueSize, hubLabelSize,
-    iconSize, hubIconSize,
-    strokeBase, dashArray, packetR,
-  } = layout;
-
-  const positions = getNodePositions(fields.length, cx, cy, radius);
-  const ready = width > 0 && height > 0;
-
   return (
-    <div ref={containerRef} className="w-full h-full min-h-[250px]">
-      {ready && (
-        <svg
-          viewBox={`0 0 ${width} ${height}`}
-          className="w-full h-full"
-          preserveAspectRatio="xMidYMid meet"
-        >
-          {/* Connection lines */}
-          {positions.map((pos, i) => {
-            const active = hovered === i;
-            return (
-              <g key={`line-${i}`}>
-                <motion.line
-                  x1={cx}
-                  y1={cy}
-                  x2={pos.x}
-                  y2={pos.y}
-                  stroke={T.green}
-                  strokeDasharray={dashArray}
-                  animate={
-                    reduceMotion
-                      ? {
-                          strokeWidth: active ? strokeBase * 2 : strokeBase,
-                          strokeOpacity: active ? 0.6 : 0.2,
-                        }
-                      : {
-                          strokeDashoffset: [0, -(width * 0.035)],
-                          strokeWidth: active ? strokeBase * 2 : strokeBase,
-                          strokeOpacity: active ? 0.6 : 0.2,
-                        }
-                  }
-                  transition={{
-                    strokeDashoffset: {
-                      duration: active ? 0.5 : 1.5,
-                      repeat: Infinity,
-                      ease: "linear",
-                    },
-                    strokeWidth: { duration: 0.2 },
-                    strokeOpacity: { duration: 0.2 },
-                  }}
-                />
-                {!reduceMotion && (
-                  <motion.circle
-                    r={active ? packetR * 1.6 : packetR}
-                    fill={T.green}
-                    animate={{
-                      cx: [cx, pos.x],
-                      cy: [cy, pos.y],
-                      opacity: [0, 0.8, 0.8, 0],
-                    }}
-                    transition={{
-                      duration: 2.5,
-                      delay: i * 0.8 + 1,
-                      repeat: Infinity,
-                      repeatDelay: active ? 0.2 : 2.5,
-                      ease: "linear",
-                    }}
-                  />
-                )}
-              </g>
-            );
-          })}
-
-          {/* Central hub */}
-          <motion.g
-            initial={reduceMotion ? false : { opacity: 0, scale: 0 }}
-            animate={{ opacity: 1, scale: 1 }}
-            transition={{ type: "spring", stiffness: 180, damping: 14 }}
-            style={{ transformOrigin: `${cx}px ${cy}px` }}
-          >
-            <circle
-              cx={cx}
-              cy={cy}
-              r={hubR}
-              fill={T.bg}
-              stroke={T.green}
-              strokeWidth={strokeBase * 2}
-            />
-            <foreignObject
-              x={cx - hubIconSize / 2}
-              y={cy - hubIconSize / 2}
-              width={hubIconSize}
-              height={hubIconSize}
-            >
-              <FiMessageCircle
-                className="text-terminal-green"
-                style={{ width: "100%", height: "100%", margin: "0 auto" }}
-              />
-            </foreignObject>
-            <text
-              x={cx}
-              y={cy + hubR + labelSize * 2}
-              textAnchor="middle"
-              fontSize={labelSize}
-              fontFamily="'Fira Code', 'Courier New', monospace"
-              fill={T.green}
-              fontWeight="bold"
-              stroke={T.bg}
-              strokeWidth={labelSize * 0.35}
-              paintOrder="stroke"
-            >
-              CONTACT ME
-            </text>
-          </motion.g>
-
-          {/* Satellite nodes */}
-          {positions.map((pos, i) => {
-            const field = fields[i];
-            const isEmail = field.key === "EMAIL";
-            const Icon = ICON_MAP[field.key] || FALLBACK_ICON;
-            const active = hovered === i;
-
-            const nodeContent = (
-              <>
-                {/* Hover glow ring */}
-                <circle
-                  cx={pos.x}
-                  cy={pos.y}
-                  r={nodeR * 1.15}
-                  fill="none"
-                  stroke={T.green}
-                  strokeWidth={strokeBase * 0.7}
-                  opacity={active ? 0.4 : 0}
-                  style={{ transition: "opacity 0.2s" }}
-                />
-
-                {/* Node circle */}
-                <circle
-                  cx={pos.x}
-                  cy={pos.y}
-                  r={nodeR}
-                  fill={T.bg}
-                  stroke={active ? T.green : T.border}
-                  strokeWidth={active ? strokeBase * 2 : strokeBase}
-                  style={{ transition: "stroke 0.2s, stroke-width 0.2s" }}
-                />
-
-                {/* Icon */}
-                <foreignObject
-                  x={pos.x - iconSize / 2}
-                  y={pos.y - iconSize / 2}
-                  width={iconSize}
-                  height={iconSize}
-                >
-                  <Icon
-                    className={active ? "text-terminal-green" : "text-terminal-dim"}
-                    style={{
-                      width: iconSize * 0.875,
-                      height: iconSize * 0.875,
-                      margin: "0 auto",
-                      transition: "color 0.2s",
-                    }}
-                  />
-                </foreignObject>
-
-                {/* Value */}
-                <text
-                  x={pos.x}
-                  y={pos.y + nodeR + valueSize * 2}
-                  textAnchor="middle"
-                  fontSize={valueSize}
-                  fontFamily="'Fira Code', 'Courier New', monospace"
-                  fontWeight="bold"
-                  fill={active ? T.green : T.dim}
-                  stroke={T.bg}
-                  strokeWidth={valueSize * 0.35}
-                  paintOrder="stroke"
-                  style={{ transition: "fill 0.2s" }}
-                >
-                  {isEmail && copied ? "COPIED!" : field.value}
-                </text>
-              </>
-            );
-
-            return (
-              <motion.g
-                key={field.key}
-                initial={reduceMotion ? false : { opacity: 0, scale: 0 }}
-                animate={{ opacity: 1, scale: 1 }}
-                transition={{
-                  delay: i * 0.15 + 0.2,
-                  type: "spring",
-                  stiffness: 180,
-                  damping: 14,
-                }}
-                style={{ transformOrigin: `${pos.x}px ${pos.y}px` }}
-                onMouseEnter={() => setHovered(i)}
-                onMouseLeave={() => setHovered(null)}
-                onTouchStart={() => setHovered(i)}
-                onTouchEnd={() => setHovered(null)}
-                className="cursor-pointer"
-              >
-                {isEmail ? (
-                  <g
-                    onClick={() => handleCopyEmail(field.value)}
-                    role="button"
-                    aria-label={`Copy email: ${field.value}`}
-                  >
-                    {nodeContent}
-                  </g>
-                ) : (
-                  <a
-                    href={field.url || "#"}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    aria-label={`${field.key}: ${field.value}`}
-                  >
-                    {nodeContent}
-                  </a>
-                )}
-              </motion.g>
-            );
-          })}
-        </svg>
-      )}
+    <div className="flex items-center gap-2 t-body">
+      <span className="relative flex h-2.5 w-2.5 shrink-0">
+        {!reduce && (
+          <span className="absolute inline-flex h-full w-full rounded-full bg-terminal-green opacity-60 animate-ping" />
+        )}
+        <span className="relative inline-flex h-2.5 w-2.5 rounded-full bg-terminal-green" />
+      </span>
+      <span className="text-terminal-green font-bold">available for work</span>
+      <span className="text-terminal-dim">· {time ?? "--:--"} local</span>
     </div>
   );
 }
 
+function ConnectionRow({ field }: { field: ProfileField }) {
+  const Icon = ICON_MAP[field.key] ?? FiMail;
+  const isEmail = field.key === "EMAIL";
+  const { copied, copy } = useCopy(isEmail ? field.value : field.url ?? field.value);
+
+  return (
+    <div className="group flex items-center gap-3 px-3 py-2 border border-terminal-border rounded-sm bg-terminal-bg transition-colors hover:border-terminal-green/50">
+      <Icon className="w-4 h-4 shrink-0 text-terminal-dim transition-colors group-hover:text-terminal-green" />
+      <div className="min-w-0 flex-1">
+        <div className="t-body text-terminal-green truncate">{field.value}</div>
+      </div>
+      <div className="flex items-center gap-0.5 shrink-0">
+        <button
+          type="button"
+          onClick={copy}
+          aria-label={`Copy ${field.key.toLowerCase()}`}
+          className="p-1.5 text-terminal-dim transition-colors hover:text-terminal-green"
+        >
+          {copied ? (
+            <FiCheck className="w-3.5 h-3.5 text-terminal-green" />
+          ) : (
+            <FiCopy className="w-3.5 h-3.5" />
+          )}
+        </button>
+        {field.url &&
+          (isEmail ? (
+            <a
+              href={field.url}
+              aria-label="Email James"
+              className="p-1.5 text-terminal-dim transition-colors hover:text-terminal-green"
+            >
+              <FiExternalLink className="w-3.5 h-3.5" />
+            </a>
+          ) : (
+            <ExternalLink
+              href={field.url}
+              aria-label={`Open ${field.key.toLowerCase()}`}
+              className="p-1.5 text-terminal-dim transition-colors hover:text-terminal-green"
+            >
+              <FiExternalLink className="w-3.5 h-3.5" />
+            </ExternalLink>
+          ))}
+      </div>
+    </div>
+  );
+}
+
+function Composer() {
+  const reduce = useReducedMotion();
+  const [subject, setSubject] = useState("");
+  const [message, setMessage] = useState("");
+  const [sent, setSent] = useState(false);
+  const { copied, copy } = useCopy(EMAIL);
+
+  // ── Single integration point ──
+  // Static export has no backend, so we hand off to the visitor's mail client.
+  // To deliver straight to an inbox instead, replace this body with a
+  // `fetch("https://formspree.io/f/<id>", { method: "POST", … })`.
+  const deliver = useCallback((subj: string, body: string) => {
+    window.location.href = `mailto:${EMAIL}?subject=${encodeURIComponent(subj)}&body=${encodeURIComponent(body)}`;
+  }, []);
+
+  const onSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!message.trim()) return;
+    const subj = subject.trim() || DEFAULT_SUBJECT;
+    setSent(true);
+    deliver(subj, message);
+  };
+
+  const canSend = message.trim().length > 0;
+
+  return (
+    <form
+      onSubmit={onSubmit}
+      className="flex flex-col overflow-hidden rounded-sm border border-terminal-border bg-terminal-bg-light/40 lg:flex-1 lg:min-h-0"
+    >
+      <div className="flex items-center gap-2 border-b border-terminal-border bg-terminal-bg-light/60 px-3 py-2 t-micro text-terminal-dim">
+        <FiSend className="w-3 h-3" /> compose — mail james
+      </div>
+
+      <div className="flex flex-col gap-3 p-3 lg:flex-1 lg:min-h-0">
+        <div className="flex items-center gap-2 t-body">
+          <span className="font-bold text-terminal-amber">To:</span>
+          <span className="truncate text-terminal-green">{EMAIL}</span>
+          <FiCheck className="w-3.5 h-3.5 shrink-0 text-terminal-green" />
+        </div>
+
+        <label className="flex flex-col gap-1">
+          <span className="t-micro font-bold text-terminal-amber">Subject:</span>
+          <input
+            value={subject}
+            onChange={(e) => setSubject(e.target.value)}
+            placeholder={DEFAULT_SUBJECT}
+            className="rounded-sm border border-terminal-border bg-terminal-bg px-2 py-1.5 t-body text-terminal-green caret-terminal-green outline-none transition-colors placeholder:text-terminal-dim/40 focus:border-terminal-green/60"
+          />
+        </label>
+
+        <label className="flex flex-col gap-1 lg:flex-1 lg:min-h-0">
+          <span className="t-micro font-bold text-terminal-amber">Message:</span>
+          <textarea
+            value={message}
+            onChange={(e) => setMessage(e.target.value)}
+            placeholder="type your message…"
+            className="min-h-[140px] resize-none rounded-sm border border-terminal-border bg-terminal-bg px-2 py-1.5 t-body text-terminal-green caret-terminal-green outline-none transition-colors placeholder:text-terminal-dim/40 focus:border-terminal-green/60 lg:flex-1"
+          />
+        </label>
+
+        {sent && (
+          <motion.div
+            initial={reduce ? false : { opacity: 0, y: 4 }}
+            animate={{ opacity: 1, y: 0 }}
+            className="t-micro space-y-0.5 border-l-2 border-terminal-green/50 pl-2"
+          >
+            <div className="text-terminal-dim break-all">
+              $ mail -s &quot;{subject.trim() || DEFAULT_SUBJECT}&quot; james
+            </div>
+            <div className="text-terminal-green">✓ message composed — opening your mail client…</div>
+          </motion.div>
+        )}
+
+        <div className="flex items-center justify-between gap-2 pt-1">
+          <button
+            type="button"
+            onClick={copy}
+            className="t-micro text-terminal-dim transition-colors hover:text-terminal-green"
+          >
+            {copied ? "copied!" : "or copy address"}
+          </button>
+          <button
+            type="submit"
+            disabled={!canSend}
+            className={cn(
+              "flex items-center gap-2 rounded-sm border px-4 py-1.5 t-body font-bold transition-colors",
+              canSend
+                ? "border-terminal-green text-terminal-green hover:bg-terminal-green/10"
+                : "cursor-not-allowed border-terminal-border text-terminal-dim",
+            )}
+          >
+            <FiSend className="w-3.5 h-3.5" /> send
+          </button>
+        </div>
+      </div>
+    </form>
+  );
+}
+
 export const ContactPage: React.FC = () => {
+  const reduce = useReducedMotion();
+
   return (
     <TerminalPage
-      command="netstat ~/contacts"
-      footer={(search) => {
-        const q = search.toLowerCase();
-        const filtered = CONTACT_FIELDS.filter(
-          (f) => !q || filterContact(f, q),
-        );
-        return filtered.length === CONTACT_FIELDS.length
-          ? `${CONTACT_FIELDS.length} nodes · all connections active`
-          : `${filtered.length} of ${CONTACT_FIELDS.length} nodes`;
-      }}
+      command="./contact.sh"
+      showSearch={false}
+      footer="I read every message"
     >
-      {(search) => {
-        const q = search.toLowerCase();
-        const filtered = CONTACT_FIELDS.filter(
-          (f) => !q || filterContact(f, q),
-        );
-        return <ContactGraph fields={filtered} />;
-      }}
+      {() => (
+        <motion.div
+          className="grid gap-4 lg:h-full lg:grid-cols-2 lg:gap-6"
+          variants={colVariants}
+          initial={reduce ? false : "hidden"}
+          animate="visible"
+        >
+          {/* Left — identity, status & connections */}
+          <motion.div className="flex flex-col gap-4 lg:min-h-0" variants={itemVariants}>
+            <p className="t-body text-terminal-dim leading-relaxed">
+              Let&apos;s build something. Reach me on any channel — or send a message right here.
+            </p>
+
+            <StatusLine />
+
+            <div className="flex flex-col gap-2">
+              {CONTACT_FIELDS.map((field) => (
+                <ConnectionRow key={field.key} field={field} />
+              ))}
+            </div>
+          </motion.div>
+
+          {/* Right — message composer */}
+          <motion.div className="flex flex-col lg:min-h-0" variants={itemVariants}>
+            <Composer />
+          </motion.div>
+        </motion.div>
+      )}
     </TerminalPage>
   );
 };

--- a/src/components/pages/education-page.tsx
+++ b/src/components/pages/education-page.tsx
@@ -14,8 +14,9 @@ export const EducationPage: React.FC = () => {
       items={education}
       getKey={(e) => e.hash}
       filterFn={filterEducation}
-      renderEntry={(e) => (
+      renderEntry={(e, index) => (
         <TimelineEntry
+          index={index}
           hash={e.hash}
           period={e.period}
           title={e.institution}

--- a/src/components/pages/experience-page.tsx
+++ b/src/components/pages/experience-page.tsx
@@ -14,8 +14,9 @@ export const ExperiencePage: React.FC = () => {
       items={experiences}
       getKey={(e) => e.hash}
       filterFn={filterExperience}
-      renderEntry={(e) => (
+      renderEntry={(e, index) => (
         <TimelineEntry
+          index={index}
           hash={e.hash}
           period={e.period}
           title={e.role}

--- a/src/components/pages/page-layout.tsx
+++ b/src/components/pages/page-layout.tsx
@@ -31,7 +31,7 @@ export const PageLayout: React.FC = () => {
   const PageComponent = PAGES[index].component;
 
   return (
-    <div className="flex flex-col h-dvh overflow-hidden pt-[41px]">
+    <div className="flex flex-col h-dvh overflow-hidden pt-[38px]">
       {/* Terminal tabs */}
       <div className="shrink-0 bg-terminal-bg-light flex">
         {PAGES.map((page, i) => (

--- a/src/components/terminal-page.tsx
+++ b/src/components/terminal-page.tsx
@@ -6,7 +6,7 @@ import { useReducedMotion } from "framer-motion";
 import { cn } from "@/lib/utils";
 import { useRevealCount } from "@/lib/use-reveal-count";
 
-function useTypewriter(text: string, speed = 30) {
+function useTypewriter(text: string, speed = 48) {
   const reduceMotion = useReducedMotion();
   const { count, done } = useRevealCount(text.length, speed);
   const [showCursor, setShowCursor] = useState(true);

--- a/src/components/timeline-entry.tsx
+++ b/src/components/timeline-entry.tsx
@@ -1,7 +1,55 @@
-import React from "react";
+"use client"
+
+import React, { useEffect, useState } from "react";
 import { FiChevronRight } from "react-icons/fi";
+import { useReducedMotion } from "framer-motion";
 import { BadgeList } from "@/components/detail-modal";
+import { TIMELINE_CADENCE } from "@/lib/motion";
 import { Tag } from "@/data/content";
+
+const HEX = "0123456789abcdef";
+
+/**
+ * A commit hash that scrambles through random hex then resolves left-to-right —
+ * a "computing the SHA" shimmer, fired `startDelayMs` after mount so it lands in
+ * sync with the timeline's sequential draw-in. Renders the real hash immediately
+ * for reduced-motion / SSR (so first paint matches and there's no hydration gap).
+ */
+function ScrambleHash({ text, startDelayMs = 0 }: { text: string; startDelayMs?: number }) {
+  const reduceMotion = useReducedMotion();
+  const [display, setDisplay] = useState(text);
+
+  useEffect(() => {
+    if (reduceMotion) {
+      setDisplay(text);
+      return;
+    }
+    let intervalId: ReturnType<typeof setInterval> | undefined;
+    const startId = setTimeout(() => {
+      const totalFrames = 24; // ~0.6s at 25ms/frame
+      let frame = 0;
+      intervalId = setInterval(() => {
+        frame++;
+        const locked = Math.floor((frame / totalFrames) * text.length);
+        let out = "";
+        for (let i = 0; i < text.length; i++) {
+          out += i < locked ? text[i] : HEX[Math.floor(Math.random() * HEX.length)];
+        }
+        setDisplay(out);
+        if (frame >= totalFrames) {
+          setDisplay(text);
+          clearInterval(intervalId);
+        }
+      }, 25);
+    }, startDelayMs);
+    return () => {
+      clearTimeout(startId);
+      if (intervalId) clearInterval(intervalId);
+    };
+  }, [text, reduceMotion, startDelayMs]);
+
+  return <span className="text-terminal-cyan">{display}</span>;
+}
 
 /** The hover-affordance chevron shared by timeline rows and project cards. */
 export function RowChevron() {
@@ -17,14 +65,16 @@ interface TimelineEntryProps {
   subtitle: string;
   detailLine: string;
   tags: Tag[];
+  /** Row position — used to sync the hash scramble to the draw-in cadence. */
+  index: number;
 }
 
 /** One commit-style row in a git-log timeline (education, experience). */
-export function TimelineEntry({ hash, period, title, subtitle, detailLine, tags }: TimelineEntryProps) {
+export function TimelineEntry({ hash, period, title, subtitle, detailLine, tags, index }: TimelineEntryProps) {
   return (
     <>
       <div className="flex flex-wrap items-center gap-2 mb-1">
-        <span className="text-terminal-cyan">{hash}</span>
+        <ScrambleHash text={hash} startDelayMs={index * TIMELINE_CADENCE * 1000} />
         <span className="text-terminal-amber">{period}</span>
       </div>
       <div className="flex items-center gap-2 mb-1">

--- a/src/components/timeline-list.tsx
+++ b/src/components/timeline-list.tsx
@@ -1,9 +1,9 @@
 "use client"
 
 import React, { useState, useRef, useCallback, useEffect } from "react";
-import { motion, useReducedMotion } from "framer-motion";
+import { motion, useReducedMotion, type Variants } from "framer-motion";
 import { TerminalPage } from "@/components/terminal-page";
-import { staggerContainer, fadeIn } from "@/lib/motion";
+import { staggerContainer, fadeIn, REVEAL_STAGGER, TIMELINE_CADENCE } from "@/lib/motion";
 import { cn } from "@/lib/utils";
 
 interface TimelineListProps<T> {
@@ -11,14 +11,49 @@ interface TimelineListProps<T> {
   items: T[];
   getKey: (item: T) => string;
   filterFn: (item: T, query: string) => boolean;
-  renderEntry: (item: T) => React.ReactNode;
+  renderEntry: (item: T, index: number) => React.ReactNode;
   renderItem?: (item: T, onClick: () => void) => React.ReactNode;
   renderModal: (item: T | null, onClose: () => void) => React.ReactNode;
   renderFooter: (filtered: number, total: number) => React.ReactNode;
 }
 
-const containerVariants = staggerContainer();
+// Timeline rows fire on the cadence beat; the denser project-card list keeps a
+// tighter fade-stagger (it has no branch line to draw).
+const timelineContainer = staggerContainer(TIMELINE_CADENCE);
+const cardContainer = staggerContainer(REVEAL_STAGGER / 2);
+
+// Projects (card list) keep their rise-fade (duration inherited from REVEAL_DURATION).
 const itemVariants = fadeIn({ y: 8 });
+
+// Git-log timeline — the graph draws itself as one continuous line. The row's
+// elements all fire on the same beat (the container stagger spaces beats by
+// TIMELINE_CADENCE): the commit dot springs in, a glow ripples out, and the
+// branch line below it draws downward over exactly one beat — so it reaches the
+// next commit just as that dot lights. Text fades as its own layer to keep the
+// line solid while it draws. All collapse to their resting state under
+// prefers-reduced-motion.
+const rowVariants: Variants = { hidden: {}, visible: {} };
+
+const contentVariants = fadeIn({ duration: 0.45 });
+
+const dotVariants: Variants = {
+  hidden: { scale: 0 },
+  visible: { scale: 1, transition: { type: "spring", stiffness: 340, damping: 22 } },
+};
+
+const haloVariants: Variants = {
+  hidden: { opacity: 0, scale: 0.6 },
+  visible: {
+    opacity: [0, 0.6, 0],
+    scale: [0.6, 1.8, 1.8],
+    transition: { duration: 0.55, times: [0, 0.45, 1] },
+  },
+};
+
+const lineVariants: Variants = {
+  hidden: { scaleY: 0 },
+  visible: { scaleY: 1, transition: { duration: TIMELINE_CADENCE, ease: "easeOut" } },
+};
 
 export function TimelineList<T>({ command, items, getKey, filterFn, renderEntry, renderItem, renderModal, renderFooter }: TimelineListProps<T>) {
   const [selectedKey, setSelectedKey] = useState<string | null>(null);
@@ -91,7 +126,7 @@ export function TimelineList<T>({ command, items, getKey, filterFn, renderEntry,
               ref={containerRef}
               onMouseMove={!renderItem ? handleMouseMove : undefined}
               onMouseLeave={!renderItem ? handleMouseLeave : undefined}
-              variants={containerVariants}
+              variants={renderItem ? cardContainer : timelineContainer}
               initial={reduceMotion ? false : "hidden"}
               animate="visible"
             >
@@ -111,34 +146,50 @@ export function TimelineList<T>({ command, items, getKey, filterFn, renderEntry,
                 return (
                   <motion.button
                     key={key}
-                    variants={itemVariants}
+                    variants={rowVariants}
                     onClick={() => setSelectedKey(key)}
                     className="flex w-full text-left group cursor-pointer"
                   >
                     <div className="flex flex-col items-center mr-4 shrink-0 overflow-visible">
-                      <div
-                        ref={(el) => setDotRef(index, el)}
-                        className={cn(
-                          "w-3 h-3 rounded-full bg-terminal-green border-2 mt-1 transition-all duration-200",
-                          isActive
-                            ? "border-terminal-green scale-[1.3] shadow-glow"
-                            : "border-terminal-dim group-hover:border-terminal-green",
+                      <div className="relative mt-1">
+                        {!reduceMotion && (
+                          <motion.span
+                            aria-hidden
+                            variants={haloVariants}
+                            className="absolute inset-0 rounded-full bg-terminal-green"
+                          />
                         )}
-                      />
+                        <motion.div variants={dotVariants} className="relative w-3 h-3">
+                          <div
+                            ref={(el) => setDotRef(index, el)}
+                            className={cn(
+                              "w-3 h-3 rounded-full bg-terminal-green border-2 transition-all duration-200",
+                              isActive
+                                ? "border-terminal-green scale-[1.3] shadow-glow"
+                                : "border-terminal-dim group-hover:border-terminal-green",
+                            )}
+                          />
+                        </motion.div>
+                      </div>
                       {!isLast && (
-                        <div className={cn(
-                          "w-0.5 flex-1 transition-colors duration-200",
-                          isActive ? "bg-terminal-green" : "bg-terminal-dim",
-                        )} />
+                        <motion.div
+                          variants={lineVariants}
+                          className={cn(
+                            "w-0.5 flex-1 origin-top transition-colors duration-200",
+                            isActive ? "bg-terminal-green" : "bg-terminal-dim",
+                          )}
+                        />
                       )}
                     </div>
 
-                    <div className={cn(
-                      "pb-6 flex-1 min-w-0 transition-opacity duration-200",
-                      isActive ? "opacity-100" : activeIndex !== null ? "opacity-60" : "",
-                    )}>
-                      {renderEntry(item)}
-                    </div>
+                    <motion.div variants={contentVariants} className="pb-6 flex-1 min-w-0">
+                      <div className={cn(
+                        "transition-opacity duration-200",
+                        isActive ? "opacity-100" : activeIndex !== null ? "opacity-60" : "",
+                      )}>
+                        {renderEntry(item, index)}
+                      </div>
+                    </motion.div>
                   </motion.button>
                 );
               })}

--- a/src/lib/motion.ts
+++ b/src/lib/motion.ts
@@ -1,14 +1,32 @@
 import type { Variants } from "framer-motion";
 
+/**
+ * Shared entrance-animation timing — the two knobs that pace every tab-open
+ * reveal (about, timeline, projects, contact). Bump these to slow the whole
+ * site's entrances down (or speed them up); per-page values inherit from them.
+ * Tuned for ~1s reveals.
+ */
+export const REVEAL_DURATION = 0.6;
+export const REVEAL_STAGGER = 0.16;
+
+/**
+ * Git-log timeline cadence — the beat between commits in the sequential
+ * draw-in. The branch line draws one segment over exactly this long and starts
+ * with its commit, so the segment "arrives" at the next commit just as that dot
+ * lights: one continuous line travelling top→bottom, dropping dots as it goes.
+ * Doubles as the row stagger and the per-commit hash-scramble offset.
+ */
+export const TIMELINE_CADENCE = 0.24;
+
 /** A container whose children's enter animations are staggered. */
-export const staggerContainer = (staggerChildren = 0.05): Variants => ({
+export const staggerContainer = (staggerChildren = REVEAL_STAGGER): Variants => ({
   hidden: {},
   visible: { transition: { staggerChildren } },
 });
 
 /** A child that fades — and optionally slides — into place. */
 export const fadeIn = (
-  { x = 0, y = 0, duration = 0.2 }: { x?: number; y?: number; duration?: number } = {},
+  { x = 0, y = 0, duration = REVEAL_DURATION }: { x?: number; y?: number; duration?: number } = {},
 ): Variants => ({
   hidden: { opacity: 0, x, y },
   visible: { opacity: 1, x: 0, y: 0, transition: { duration } },


### PR DESCRIPTION
## Summary
Polish pass to make the portfolio more engaging — focused on the contact page and the git-log timeline.

- **Contact page** rebuilt as a terminal panel: a working `mailto:` message composer, copyable connection rows (email / LinkedIn / GitHub), and a live "available for work" status with the owner's local time.
- **Themed 404** — a `segfault (core dumped)` / command-not-found page with a route home (works with the static export).
- **Animated git-log timeline** (education & experience) — the branch line draws top-to-bottom and lights each commit dot as it reaches it, with a per-commit hash-scramble shimmer.
- **Unified entrance timing** — every tab-open reveal is paced by three constants in `motion.ts` (`REVEAL_DURATION`, `REVEAL_STAGGER`, `TIMELINE_CADENCE`) for easy tuning.
- **Layout fix** — closed a ~3px gap between the fixed header and the tabs.

## Notes
- No new dependencies; reuses existing tokens, motion presets, and the `TerminalPage` wrapper. `prefers-reduced-motion` respected throughout.
- Static-export friendly: the composer hands off to the visitor's mail client via `mailto:` (single isolated `deliver()` swap-point for Formspree later).

## Verification
- `bun run build` passes (static export, 5 pages incl. `/_not-found`); `tsc --noEmit` and `next lint` clean.
- Checked in-browser at desktop + mobile: composer builds a correctly-encoded mailto, timeline draw-in + scramble play, header/tabs sit flush.
