### PR TITLE
chore: add CV as a git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "cv"]
+	path = cv
+	url = git@github.com:expiracy/cv.git


### PR DESCRIPTION
Adds [`expiracy/cv`](https://github.com/expiracy/cv) (private LaTeX CV) as a git submodule at `cv/`, pinned to `master` (`5c30fc9`).

### Details
- **Mechanism:** git submodule (live pointer to the CV's own repo), not a subtree.
- **URL:** SSH (`git@github.com:expiracy/cv.git`) to match `origin`.
- **Contents:** `cv.tex`, `cv.cls`, and a prebuilt `cv.pdf`.

### Notes
- The CV repo is **private**; this repo is **public**. `.gitmodules` exposes the URL (harmless — 404s for anyone without access), and a third-party `git clone --recurse-submodules` will 403 on `cv/`. Expected.
- **Existing Pages build is unaffected** — `actions/checkout@v4` doesn't fetch submodules and nothing imports `cv/`, so `next build` ignores it.
- Not yet wired into the site. Surfacing `cv/cv.pdf` as a downloadable résumé on the *deployed* site would need `submodules: recursive` on checkout **plus** a PAT/deploy-key secret with read access to the private CV repo.