### PR TITLE
Theme contrast pass, 3 new themes, reworked contact + projects animations

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "dev",
+      "runtimeExecutable": "bun",
+      "runtimeArgs": ["run", "dev"],
+      "port": 3000
+    }
+  ]
+}

--- a/.claude/skills/run-portfolio/.gitignore
+++ b/.claude/skills/run-portfolio/.gitignore
@@ -1,0 +1,7 @@
+# The driver's own deps + downloaded browsers are setup-time, never committed.
+node_modules/
+bun.lock
+bun.lockb
+package-lock.json
+# Screenshots the driver writes default to /tmp, but ignore any that land here.
+*.png

--- a/.claude/skills/run-portfolio/SKILL.md
+++ b/.claude/skills/run-portfolio/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: run-portfolio
+description: Run, build, preview, screenshot, or smoke-test the terminal-themed portfolio site. Builds the static Next.js export, serves it, and drives the running SPA (five terminal tabs + the colour-theme switcher) with a headless Playwright driver that screenshots every step. Use when asked to launch/start/run the portfolio, take screenshots of it, or confirm a UI change renders.
+---
+
+# Run the portfolio
+
+A terminal/CRT-themed personal site: **Next.js 14 App Router, `output: "export"`** (fully static, no server runtime), one route, a tabbed SPA (about / education / experience / projects / contact) with seven switchable colour themes. Managed with **Bun**.
+
+There is no API and no test suite. You verify it by **rendering the real page in a headless browser** and looking. The driver for that is committed next to this file:
+
+- **Driver:** [`driver.mjs`](driver.mjs) — headless-chromium Playwright script. Points at an already-running server, clicks through all five tabs, switches the theme, screenshots each step, and asserts on the DOM (`HTTP ok`, `html[data-theme]` flips, 5 tabs present, zero console errors). Exits non-zero on any failure, so it doubles as a smoke test.
+
+All paths below are **relative to the repo root** (the directory with `package.json`). Verified on macOS (darwin); Linux notes are called out where they differ.
+
+## Prerequisites
+
+- **Bun** and **Node** on PATH (`bun 1.3`, `node 26` used here). `python3` for the static file server (or substitute any static server).
+- **One-time harness setup** — installs Playwright into the *skill's own* `node_modules` (kept out of the app's `package.json` on purpose) and downloads the chromium build (~95 MB, cached in `~/Library/Caches/ms-playwright`):
+
+```bash
+bun add --cwd .claude/skills/run-portfolio playwright
+.claude/skills/run-portfolio/node_modules/.bin/playwright install chromium
+```
+
+> Linux: use `.claude/skills/run-portfolio/node_modules/.bin/playwright install --with-deps chromium` instead — `--with-deps` pulls the system libraries headless chromium needs. (Not exercised here; this machine is macOS.)
+
+## Build
+
+```bash
+bun install              # app deps (skip if node_modules is present)
+bun run build            # static export → ./out
+```
+
+`bun run build` writes the site to `out/` (`index.html`, `404.html`, `_next/…`). Assets are referenced with **absolute** `/_next/…` paths, so the build must be served over **HTTP from the directory root** — opening `out/index.html` as a `file://` URL gives an unstyled, broken page.
+
+## Run (agent path — this is the one to use)
+
+Two steps: serve the build, then drive it. Run the server in the background (or a second shell).
+
+```bash
+# 1. serve the static export (port 8000 was free here; pick any free port)
+python3 -m http.server -d out 8000
+
+# 2. drive it — screenshots land in /tmp/portfolio-shots
+node .claude/skills/run-portfolio/driver.mjs --url http://localhost:8000
+```
+
+Expected tail — **11/11**, and six PNGs on disk:
+
+```
+PASS  page loads (HTTP ok)  — status 200 @ http://localhost:8000
+PASS  app hydrated  — header + data-theme present
+PASS  tab bar has 5 tabs  — found 5
+PASS  tab: about  — /tmp/portfolio-shots/tab-0-about.png
+...
+PASS  theme → vaporwave  — button reads "[vaporwave]"
+PASS  no page/console errors
+
+11/11 checks passed — screenshots in /tmp/portfolio-shots
+```
+
+Then **look at the screenshots** (e.g. `/tmp/portfolio-shots/theme-vaporwave.png`) — a green/0 check count is necessary but not sufficient; a blank-but-200 page still "passes" the HTTP check.
+
+Driver flags:
+
+| Flag | Default | Notes |
+|------|---------|-------|
+| `--url <url>` | `http://localhost:8000` | server to drive (also `BASE_URL` env) |
+| `--theme <name>` | `vaporwave` | `green` `pink` `blue` `light` `synthwave` `cyberpunk` `vaporwave` |
+| `--out <dir>` | `/tmp/portfolio-shots` | screenshot directory (also `SHOT_DIR` env) |
+
+## Run (dev server — fast iteration loop)
+
+For live editing, drive `next dev` instead of rebuilding. **It does not match production** — see the framer gotcha below.
+
+```bash
+bun dev                  # http://localhost:3000 … but see port note
+node .claude/skills/run-portfolio/driver.mjs --url http://localhost:3001
+```
+
+> `bun dev` **auto-increments the port** if 3000 is taken (it logs e.g. `Port 3000 is in use, trying 3001 instead` → `Local: http://localhost:3001`). Point `--url` at the port it actually logged, not 3000.
+
+## Run (human path)
+
+```bash
+bun dev                  # open the logged URL in a browser, Ctrl-C to stop
+```
+
+Useless headless — it just spawns a server and waits.
+
+## Inside Claude Code
+
+The `preview_*` MCP tools (`preview_start`, then `preview_screenshot` / `preview_snapshot`) are a zero-setup alternative to the Playwright driver for a quick look — no `playwright install` needed. Use the committed `driver.mjs` when you want the scripted tab/theme walk-through, a portable CI-runnable harness, or a pass/fail exit code.
+
+## Gotchas
+
+- **Static export needs an HTTP root.** Absolute `/_next/…` asset paths mean `file://` and "serve a subdirectory" both break styling. Serve `out/` itself at `/`.
+- **Theme lives on `<html>`.** The provider sets `document.documentElement.dataset.theme` and `localStorage["theme"]` *after hydration*. Server HTML ships `class="dark"` with **no** `data-theme` until JS boots — the driver waits for `html[data-theme]` as its "hydrated" signal. Seven themes are real (`src/lib/themes.ts`); an older note about "back to 4 themes" is stale.
+- **Tab labels are width-gated.** The five tab buttons render their text in a `hidden md:inline` span, so below 768px they're icon-only with no accessible name. The driver uses a 1280px viewport and selects the five `button.font-bold` tabs by index — don't shrink the viewport or text selectors vanish.
+- **Framer entrance animations freeze in `bun dev`, run in the export.** `reactStrictMode` double-invoke plus the typewriter command re-rendering the subtree restart framer's container-stagger every frame, so staggered entrances (git-log timeline, About ASCII reveal) sit at their first frame in dev. They animate correctly in the static export. Don't chase it as a bug — **screenshot the built `out/` (port 8000 path), not dev.** Content is still present in dev (only the entrance animation is stuck), so the smoke checks pass either way.
+- **Playwright is the skill's dep, not the app's.** It installs under `.claude/skills/run-portfolio/node_modules`; the app's `package.json` stays clean. The skill's own `node_modules`/lockfile are git-ignored.
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| `Cannot find package 'playwright'` | Run the one-time `bun add --cwd .claude/skills/run-portfolio playwright` setup line. |
+| `browserType.launch: Executable doesn't exist …` | Browser not downloaded: `.claude/skills/run-portfolio/node_modules/.bin/playwright install chromium`. |
+| Driver `goto` times out / `ECONNREFUSED` | No server on that port. Start `python3 -m http.server -d out 8000` (or `bun dev`) first, and match `--url` to the running port. |
+| Page renders unstyled / 404s on `_next/*` | Served from the wrong root or via `file://`. Serve `out/` at `/` over HTTP. |
+| (Linux) chromium fails to launch on missing `.so` | Reinstall with deps: `… playwright install --with-deps chromium`. |
+
+## Static check
+
+No unit tests exist; the driver's exit code is the smoke test. For lint:
+
+```bash
+bun run lint             # next lint → "No ESLint warnings or errors"
+```

--- a/.claude/skills/run-portfolio/driver.mjs
+++ b/.claude/skills/run-portfolio/driver.mjs
@@ -1,0 +1,89 @@
+// Playwright smoke driver for the terminal-themed portfolio (a static Next.js SPA).
+//
+// It launches headless chromium, points it at an already-running server, and
+// drives the real UI: loads the page, clicks through all five terminal tabs,
+// switches the colour theme, and screenshots each step. It asserts on the DOM
+// (HTTP ok, header present, `html[data-theme]` flips) and prints a PASS/FAIL
+// summary, exiting non-zero if anything failed — so it works as a smoke test too.
+//
+// This driver does NOT start a server. Bring one up first (see SKILL.md):
+//   prod : bun run build && python3 -m http.server -d out 8000   (default)
+//   dev  : bun dev                                               (--url http://localhost:3000)
+//
+// Usage:
+//   node driver.mjs                                  # http://localhost:8000, shots in /tmp/portfolio-shots
+//   node driver.mjs --url http://localhost:3000      # drive the dev server instead
+//   node driver.mjs --theme cyberpunk --out /tmp/x   # pick theme + screenshot dir
+//
+import { chromium } from "playwright";
+import { mkdirSync } from "node:fs";
+import { join } from "node:path";
+
+const argv = process.argv.slice(2);
+const opt = (name, fallback) => {
+  const i = argv.indexOf(`--${name}`);
+  return i >= 0 && argv[i + 1] ? argv[i + 1] : fallback;
+};
+
+const BASE_URL = opt("url", process.env.BASE_URL || "http://localhost:8000");
+const OUT_DIR = opt("out", process.env.SHOT_DIR || "/tmp/portfolio-shots");
+const THEME = opt("theme", "vaporwave"); // green | pink | blue | light | synthwave | cyberpunk | vaporwave
+const TABS = ["about", "education", "experience", "projects", "contact"];
+
+mkdirSync(OUT_DIR, { recursive: true });
+
+const results = [];
+const check = (name, ok, detail = "") => {
+  results.push(ok);
+  console.log(`${ok ? "PASS" : "FAIL"}  ${name}${detail ? `  — ${detail}` : ""}`);
+};
+
+const browser = await chromium.launch();
+const page = await browser.newPage({ viewport: { width: 1280, height: 850 } });
+
+// Treat uncaught page errors / console errors as failures.
+const errors = [];
+page.on("pageerror", (e) => errors.push(`pageerror: ${e.message}`));
+page.on("console", (m) => m.type() === "error" && errors.push(`console: ${m.text()}`));
+
+try {
+  const resp = await page.goto(BASE_URL, { waitUntil: "networkidle", timeout: 30000 });
+  check("page loads (HTTP ok)", !!resp && resp.ok(), `status ${resp && resp.status()} @ ${BASE_URL}`);
+
+  // Provider sets data-theme on <html> after hydration — proves JS booted.
+  await page.waitForSelector("html[data-theme]", { timeout: 10000 });
+  await page.getByText("james_gray").first().waitFor({ timeout: 10000 });
+  check("app hydrated", true, "header + data-theme present");
+
+  // The five tabs are the only `font-bold` buttons; click each by index, screenshot.
+  const tabs = page.locator("button.font-bold");
+  const tabCount = await tabs.count();
+  check("tab bar has 5 tabs", tabCount === TABS.length, `found ${tabCount}`);
+  for (let i = 0; i < TABS.length; i++) {
+    await tabs.nth(i).click();
+    await page.waitForTimeout(450); // let the tab's content mount
+    const file = join(OUT_DIR, `tab-${i}-${TABS[i]}.png`);
+    await page.screenshot({ path: file });
+    check(`tab: ${TABS[i]}`, true, file);
+  }
+
+  // Theme switch: open the [theme] menu, pick THEME, confirm <html> + button label flip.
+  await page.getByRole("button", { name: "Change theme" }).click();
+  await page.getByRole("button", { name: THEME, exact: true }).click();
+  await page.waitForSelector(`html[data-theme="${THEME}"]`, { timeout: 5000 });
+  const label = (await page.getByRole("button", { name: "Change theme" }).textContent())?.trim();
+  check(`theme → ${THEME}`, label === `[${THEME}]`, `button reads "${label}"`);
+  const themeShot = join(OUT_DIR, `theme-${THEME}.png`);
+  await page.screenshot({ path: themeShot });
+  check("theme screenshot", true, themeShot);
+
+  check("no page/console errors", errors.length === 0, errors.slice(0, 3).join(" | "));
+} catch (err) {
+  check("driver run", false, err.message);
+} finally {
+  await browser.close();
+}
+
+const passed = results.filter(Boolean).length;
+console.log(`\n${passed}/${results.length} checks passed — screenshots in ${OUT_DIR}`);
+process.exit(passed === results.length ? 0 : 1);

--- a/.claude/skills/run-portfolio/package.json
+++ b/.claude/skills/run-portfolio/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "run-portfolio-driver",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Self-contained Playwright smoke driver for the portfolio. Kept out of the app's package.json on purpose.",
+  "scripts": {
+    "smoke": "node driver.mjs"
+  },
+  "dependencies": {
+    "playwright": "^1.61.0"
+  }
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -19,7 +19,7 @@
 
 [data-theme="pink"] {
   --t-green: #ff66b2;
-  --t-dim: #cc44aa;
+  --t-dim: #d65cbb;
   --t-cyan: #d580ff;
   --t-amber: #ff44aa;
   --t-red: #ff3366;
@@ -33,7 +33,7 @@
 
 [data-theme="blue"] {
   --t-green: #00aaff;
-  --t-dim: #0077cc;
+  --t-dim: #2e93dd;
   --t-cyan: #66ddff;
   --t-amber: #ff8800;
   --t-red: #ff3333;
@@ -46,17 +46,61 @@
 }
 
 [data-theme="light"] {
-  --t-green: #1a7a35;
-  --t-dim: #4a8a5a;
+  /* "Darken the ink": warm paper background kept; text/accents deepened and
+     borders firmed so secondary text clears the WCAG AA 4.5:1 bar. */
+  --t-green: #136b2c;
+  --t-dim: #3d7a4d;
   --t-cyan: #0055aa;
-  --t-amber: #8a5500;
-  --t-red: #bb2222;
+  --t-amber: #7a4a00;
+  --t-red: #b01f1f;
   --t-bg: #f5f5f0;
   --t-bg-light: #eaeae5;
-  --t-border: #1a7a3540;
-  --t-glow: #1a7a35;
+  --t-border: #176b2f59;
+  --t-glow: #136b2c;
   --t-scanline: transparent;
-  --t-selection-bg: #1a7a3530;
+  --t-selection-bg: #136b2c33;
+}
+
+[data-theme="synthwave"] {
+  --t-green: #ff5cc0;
+  --t-dim: #a07ace;
+  --t-cyan: #3ce0ff;
+  --t-amber: #ff9f45;
+  --t-red: #ff4d6d;
+  --t-bg: #1a0b2e;
+  --t-bg-light: #241141;
+  --t-border: #ff5cc030;
+  --t-glow: #ff5cc0;
+  --t-scanline: #ff5cc006;
+  --t-selection-bg: #ff5cc040;
+}
+
+[data-theme="cyberpunk"] {
+  --t-green: #36e8f5;
+  --t-dim: #5fa9b5;
+  --t-cyan: #7df9ff;
+  --t-amber: #fcee0a;
+  --t-red: #ff2e97;
+  --t-bg: #0a0f12;
+  --t-bg-light: #0f161a;
+  --t-border: #36e8f530;
+  --t-glow: #36e8f5;
+  --t-scanline: #36e8f506;
+  --t-selection-bg: #36e8f540;
+}
+
+[data-theme="vaporwave"] {
+  --t-green: #ff9fda;
+  --t-dim: #ab84c6;
+  --t-cyan: #8af0ff;
+  --t-amber: #ffc488;
+  --t-red: #ff7a9e;
+  --t-bg: #1c1140;
+  --t-bg-light: #271a52;
+  --t-border: #ff9fda30;
+  --t-glow: #ff9fda;
+  --t-scanline: #ff9fda06;
+  --t-selection-bg: #ff9fda40;
 }
 
 @layer base {
@@ -155,6 +199,19 @@ body::before {
   color: var(--t-green);
 }
 
+/* ── Contact: gentle staggered fade-in. Short items rise + fade; the full-height
+   composer fades only (a transform would nudge a scrollbar on mount). Pure CSS +
+   per-element animation-delay, so the typewriter re-render can't restart it. */
+@keyframes fade-rise { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: none; } }
+.fade-rise { opacity: 0; animation: fade-rise 0.5s ease-out forwards; }
+
+@keyframes fade-soft { from { opacity: 0; } to { opacity: 1; } }
+.fade-soft { opacity: 0; animation: fade-soft 0.5s ease-out forwards; }
+
+/* ── Projects: "matrix rain" — each card fades up as its name decodes (see MatrixText). */
+@keyframes matrix-card-in { from { opacity: 0; } to { opacity: 1; } }
+.matrix-card-in { opacity: 0; animation: matrix-card-in 0.32s ease-out forwards; }
+
 @media (prefers-reduced-motion: reduce) {
   body {
     animation: none;
@@ -167,4 +224,7 @@ body::before {
   .text-glow-bright {
     text-shadow: none;
   }
+
+  .fade-rise, .fade-soft { animation: none; opacity: 1; transform: none; }
+  .matrix-card-in { animation: none; opacity: 1; }
 }

--- a/src/components/matrix-text.tsx
+++ b/src/components/matrix-text.tsx
@@ -1,0 +1,48 @@
+"use client"
+
+import React, { useState, useEffect } from "react";
+import { useReducedMotion } from "framer-motion";
+
+const GLYPHS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789#%&@*<>=/\\$+?".split("");
+const randGlyph = () => GLYPHS[Math.floor(Math.random() * GLYPHS.length)];
+const MS_PER_CHAR = 34; // how fast the decode locks characters in, left-to-right
+
+/**
+ * Reveals `text` with a Matrix-style decode: every character flickers through
+ * random glyphs, then locks into place left-to-right.
+ *
+ * Progress is read from a fixed wall-clock origin (`performance.now()`), so the
+ * decode always finishes on schedule no matter how the timer fires — 60fps in a
+ * live tab, or clamped/throttled in the background — and the TerminalPage
+ * typewriter re-rendering the list can't starve it. Self-contained with stable
+ * deps so a parent re-render never restarts it. Collapses straight to the final
+ * text under prefers-reduced-motion.
+ */
+export function MatrixText({ text, delay = 0, className }: { text: string; delay?: number; className?: string }) {
+  const reduce = useReducedMotion();
+  const [display, setDisplay] = useState("");
+
+  useEffect(() => {
+    if (reduce) {
+      setDisplay(text);
+      return;
+    }
+    const chars = text.split("");
+    const start = performance.now() + delay;
+    let timer: ReturnType<typeof setTimeout>;
+    const tick = () => {
+      const elapsed = performance.now() - start;
+      const locked = elapsed < 0 ? 0 : Math.min(chars.length, Math.floor(elapsed / MS_PER_CHAR));
+      setDisplay(chars.map((c, i) => (c === " " || i < locked ? c : randGlyph())).join(""));
+      if (locked < chars.length) timer = setTimeout(tick, 33);
+    };
+    tick();
+    return () => clearTimeout(timer);
+  }, [text, delay, reduce]);
+
+  return (
+    <span className={className} aria-label={text}>
+      {display || " "}
+    </span>
+  );
+}

--- a/src/components/pages/contact-page.tsx
+++ b/src/components/pages/contact-page.tsx
@@ -6,7 +6,6 @@ import { FiMail, FiGithub, FiLinkedin, FiCopy, FiCheck, FiExternalLink, FiSend }
 import { CONTACT_FIELDS, ProfileField } from "@/data/content";
 import { TerminalPage } from "@/components/terminal-page";
 import { ExternalLink } from "@/components/external-link";
-import { staggerContainer, fadeIn } from "@/lib/motion";
 import { cn } from "@/lib/utils";
 
 const ICON_MAP: Record<string, React.ComponentType<{ className?: string }>> = {
@@ -17,11 +16,6 @@ const ICON_MAP: Record<string, React.ComponentType<{ className?: string }>> = {
 
 const EMAIL = CONTACT_FIELDS.find((f) => f.key === "EMAIL")?.value ?? "";
 const DEFAULT_SUBJECT = "Hello from your portfolio";
-
-const colVariants = staggerContainer();
-// Opacity-only fade: a vertical translate would briefly push the full-height
-// grid past the scroll area on mount, flashing a scrollbar before it settles.
-const itemVariants = fadeIn();
 
 function useCopy(value: string) {
   const [copied, setCopied] = useState(false);
@@ -220,6 +214,12 @@ function Composer() {
 
 export const ContactPage: React.FC = () => {
   const reduce = useReducedMotion();
+  // Gentle top-to-bottom stagger: short items rise + fade; the full-height
+  // composer fades only (a transform on it would nudge a scrollbar on mount).
+  const rise = reduce ? "" : "fade-rise";
+  const fade = reduce ? "" : "fade-soft";
+  const at = (i: number): React.CSSProperties | undefined =>
+    reduce ? undefined : { animationDelay: `${i * 80}ms` };
 
   return (
     <TerminalPage
@@ -228,32 +228,31 @@ export const ContactPage: React.FC = () => {
       footer="I read every message"
     >
       {() => (
-        <motion.div
-          className="grid gap-4 lg:h-full lg:grid-cols-2 lg:gap-6"
-          variants={colVariants}
-          initial={reduce ? false : "hidden"}
-          animate="visible"
-        >
-          {/* Left — identity, status & connections */}
-          <motion.div className="flex flex-col gap-4 lg:min-h-0" variants={itemVariants}>
-            <p className="t-body text-terminal-dim leading-relaxed">
+        <div className="grid gap-4 lg:h-full lg:grid-cols-2 lg:gap-6">
+          {/* Left — identity, status & connections fade in top-to-bottom */}
+          <div className="flex flex-col gap-4 lg:min-h-0">
+            <p className={cn("t-body text-terminal-dim leading-relaxed", rise)} style={at(0)}>
               Let&apos;s build something. Reach me on any channel — or send a message right here.
             </p>
 
-            <StatusLine />
+            <div className={rise} style={at(1)}>
+              <StatusLine />
+            </div>
 
             <div className="flex flex-col gap-2">
-              {CONTACT_FIELDS.map((field) => (
-                <ConnectionRow key={field.key} field={field} />
+              {CONTACT_FIELDS.map((field, i) => (
+                <div key={field.key} className={rise} style={at(2 + i)}>
+                  <ConnectionRow field={field} />
+                </div>
               ))}
             </div>
-          </motion.div>
+          </div>
 
           {/* Right — message composer */}
-          <motion.div className="flex flex-col lg:min-h-0" variants={itemVariants}>
+          <div className={cn("flex flex-col lg:min-h-0", fade)} style={at(2)}>
             <Composer />
-          </motion.div>
-        </motion.div>
+          </div>
+        </div>
       )}
     </TerminalPage>
   );

--- a/src/components/pages/projects-page.tsx
+++ b/src/components/pages/projects-page.tsx
@@ -4,8 +4,11 @@ import React from "react";
 import { projects, filterProject } from "@/data/content";
 import { TimelineList } from "@/components/timeline-list";
 import { RowChevron } from "@/components/timeline-entry";
+import { MatrixText } from "@/components/matrix-text";
 import { DetailModal, BulletList, BadgeList, SourceLink } from "@/components/detail-modal";
 import { cn, pluralCount } from "@/lib/utils";
+
+const CARD_STEP_MS = 70; // keep in step with TimelineList's per-row reveal delay
 
 export const ProjectsPage: React.FC = () => {
   const publicCount = projects.filter(p => p.url).length;
@@ -16,7 +19,7 @@ export const ProjectsPage: React.FC = () => {
       items={projects}
       getKey={(p) => p.dir}
       filterFn={filterProject}
-      renderItem={(p, onClick) => (
+      renderItem={(p, onClick, index) => (
         <button
           onClick={onClick}
           className="relative block w-full text-left pl-7 pr-4 py-3 rounded-sm transition-all hover:bg-terminal-green/5 group border border-terminal-border hover:border-terminal-green/60 hover:shadow-marker bg-terminal-bg"
@@ -26,7 +29,7 @@ export const ProjectsPage: React.FC = () => {
           </span>
           <div className="flex items-center gap-2 mb-1">
             <span className="text-terminal-green font-bold text-sm md:text-base flex items-center gap-1 group-hover:underline">
-              {p.dir}/
+              <MatrixText text={`${p.dir}/`} delay={index * CARD_STEP_MS + 60} />
               <RowChevron />
             </span>
             <span className={cn("ml-auto shrink-0 t-micro px-1.5 py-0.5 rounded-sm border border-terminal-border", p.url ? "text-terminal-green" : "text-terminal-red")}>
@@ -36,7 +39,10 @@ export const ProjectsPage: React.FC = () => {
           <div className="text-terminal-dim t-body mb-2">
             {p.description}
           </div>
-          <BadgeList items={p.tags} />
+          {/* tags resolve last */}
+          <span className="matrix-card-in block" style={{ animationDelay: `${index * CARD_STEP_MS + 380}ms` }}>
+            <BadgeList items={p.tags} />
+          </span>
         </button>
       )}
       renderEntry={() => null}

--- a/src/components/timeline-list.tsx
+++ b/src/components/timeline-list.tsx
@@ -3,7 +3,7 @@
 import React, { useState, useRef, useCallback, useEffect } from "react";
 import { motion, useReducedMotion, type Variants } from "framer-motion";
 import { TerminalPage } from "@/components/terminal-page";
-import { staggerContainer, fadeIn, REVEAL_STAGGER, TIMELINE_CADENCE } from "@/lib/motion";
+import { staggerContainer, fadeIn, TIMELINE_CADENCE } from "@/lib/motion";
 import { cn } from "@/lib/utils";
 
 interface TimelineListProps<T> {
@@ -12,18 +12,16 @@ interface TimelineListProps<T> {
   getKey: (item: T) => string;
   filterFn: (item: T, query: string) => boolean;
   renderEntry: (item: T, index: number) => React.ReactNode;
-  renderItem?: (item: T, onClick: () => void) => React.ReactNode;
+  renderItem?: (item: T, onClick: () => void, index: number) => React.ReactNode;
   renderModal: (item: T | null, onClose: () => void) => React.ReactNode;
   renderFooter: (filtered: number, total: number) => React.ReactNode;
 }
 
-// Timeline rows fire on the cadence beat; the denser project-card list keeps a
-// tighter fade-stagger (it has no branch line to draw).
+// Timeline rows fire on the cadence beat (the git-log branch line draws between
+// them). Project cards instead fade up on a per-row CSS delay while their names
+// decode (see MatrixText) — a "matrix rain" reveal that needs no framer stagger.
 const timelineContainer = staggerContainer(TIMELINE_CADENCE);
-const cardContainer = staggerContainer(REVEAL_STAGGER / 2);
-
-// Projects (card list) keep their rise-fade (duration inherited from REVEAL_DURATION).
-const itemVariants = fadeIn({ y: 8 });
+const CARD_STEP_MS = 70; // delay between successive project rows revealing
 
 // Git-log timeline — the graph draws itself as one continuous line. The row's
 // elements all fire on the same beat (the container stagger spaces beats by
@@ -126,18 +124,22 @@ export function TimelineList<T>({ command, items, getKey, filterFn, renderEntry,
               ref={containerRef}
               onMouseMove={!renderItem ? handleMouseMove : undefined}
               onMouseLeave={!renderItem ? handleMouseLeave : undefined}
-              variants={renderItem ? cardContainer : timelineContainer}
-              initial={reduceMotion ? false : "hidden"}
-              animate="visible"
+              variants={renderItem ? undefined : timelineContainer}
+              initial={renderItem ? undefined : reduceMotion ? false : "hidden"}
+              animate={renderItem ? undefined : "visible"}
             >
               {filtered.map((item, index) => {
                 const key = getKey(item);
 
                 if (renderItem) {
                   return (
-                    <motion.div key={key} variants={itemVariants}>
-                      {renderItem(item, () => setSelectedKey(key))}
-                    </motion.div>
+                    <div
+                      key={key}
+                      className={reduceMotion ? undefined : "matrix-card-in"}
+                      style={reduceMotion ? undefined : { animationDelay: `${index * CARD_STEP_MS}ms` }}
+                    >
+                      {renderItem(item, () => setSelectedKey(key), index)}
+                    </div>
                   );
                 }
 

--- a/src/lib/themes.ts
+++ b/src/lib/themes.ts
@@ -1,7 +1,7 @@
 // Plain (non-"use client") module so the theme list is real on both the server
 // (layout's pre-hydration script) and the client (provider + header menu).
 
-export const THEMES = ["green", "pink", "blue", "light"] as const;
+export const THEMES = ["green", "pink", "blue", "light", "synthwave", "cyberpunk", "vaporwave"] as const;
 export type Theme = (typeof THEMES)[number];
 export const DEFAULT_THEME: Theme = THEMES[0];
 


### PR DESCRIPTION
## Summary

Readability + visual polish across the terminal portfolio.

### Theme contrast (all 7 themes now clear WCAG AA)
- **Light theme** — kept the warm paper background but deepened the ink and firmed up the faint borders so secondary/dim text clears the 4.5:1 AA bar (was ~3.8:1).
- **Blue** dim text ~4.25:1 (below AA) → ~6:1; **pink** dim ~4.7:1 → ~6:1. Green/light already passed.

### Three new themes
`synthwave` (neon magenta + cyan on indigo), `cyberpunk` (electric cyan + neon yellow/magenta on near-black), `vaporwave` (pastel pink + cyan on dusk purple). All tuned to AA. The header menu and the pre-hydration script derive from `THEMES`, so no other edits were needed.

### Reworked entrance animations
- **Projects** → a "matrix decode": each project name flickers through random glyphs and locks in left-to-right, cascading top-to-bottom (new `MatrixText` component).
- **Contact** → a gentle staggered fade-in (replaces an earlier scan/glow then static/tune-in attempt — both scrapped).
- Both are CSS keyframes / wall-clock-driven JS rather than framer container-staggers, so they run correctly in `dev` **and** the static export (framer entrances freeze under dev StrictMode + the typewriter re-render).

### Tooling
Adds a committed `run-portfolio` skill (builds the static export, serves it, drives it through headless Playwright — 5 tabs + theme switch, screenshots, smoke checks) and the `launch.json` preview config.

## Verification
- `tsc --noEmit`, `next lint`, and `next build` all clean.
- Contrast computed from the actual CSS: every theme's primary + dim text >= 4.5:1 on its background.
- Driven through the production export with headless Playwright: **11/11 checks, zero console errors**; both new animations confirmed in motion (contact rows cascade, project names decode top-to-bottom).