### PR TITLE
Synthwave default theme, terminal identity, and education details

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "cv"]
+	path = cv
+	url = git@github.com:expiracy/cv.git

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -13,7 +13,7 @@ const firaCode = Fira_Code({ subsets: ["latin"], weight: ["300", "400", "500", "
 const themeInitScript = `(function(){try{var t=localStorage.getItem("theme");document.documentElement.setAttribute("data-theme",${JSON.stringify(THEMES)}.indexOf(t)>-1?t:${JSON.stringify(DEFAULT_THEME)})}catch(e){document.documentElement.setAttribute("data-theme",${JSON.stringify(DEFAULT_THEME)})}})()`;
 
 export const metadata: Metadata = {
-  title: "james@portfolio:~$",
+  title: "james_gray@portfolio:~$",
   description: "James Gray — Portfolio",
 };
 

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -27,7 +27,7 @@ export const Header: React.FC = () => {
     <header className="fixed top-0 left-0 right-0 z-50 border-b border-terminal-border bg-terminal-bg backdrop-blur-sm">
       <div className="flex items-center justify-between px-4 py-2 text-sm">
         <div className="flex items-center gap-4">
-          <span className="text-terminal-dim">james_gray</span>
+          <span className="text-terminal-dim">james_gray@portfolio</span>
         </div>
         <div className="flex items-center gap-3 text-terminal-dim">
           <Link href="mailto:jameslaigray@gmail.com" className="hover:text-terminal-green transition-colors" aria-label="Email">

--- a/src/components/pages/about-me-page.tsx
+++ b/src/components/pages/about-me-page.tsx
@@ -73,7 +73,7 @@ export const AboutMePage: React.FC = () => {
             animate={done ? "visible" : "hidden"}
           >
             <motion.div className="mb-2" variants={profileItemVariants}>
-              <span className="text-terminal-cyan font-bold">james</span>
+              <span className="text-terminal-cyan font-bold">james_gray</span>
               <span className="text-terminal-dim">@</span>
               <span className="text-terminal-cyan font-bold">portfolio</span>
             </motion.div>

--- a/src/components/pages/contact-page.tsx
+++ b/src/components/pages/contact-page.tsx
@@ -143,7 +143,7 @@ function Composer() {
       className="flex flex-col overflow-hidden rounded-sm border border-terminal-border bg-terminal-bg-light/40 lg:flex-1 lg:min-h-0"
     >
       <div className="flex items-center gap-2 border-b border-terminal-border bg-terminal-bg-light/60 px-3 py-2 t-micro text-terminal-dim">
-        <FiSend className="w-3 h-3" /> compose — mail james
+        <FiSend className="w-3 h-3" /> compose — mail james_gray
       </div>
 
       <div className="flex flex-col gap-3 p-3 lg:flex-1 lg:min-h-0">
@@ -180,7 +180,7 @@ function Composer() {
             className="t-micro space-y-0.5 border-l-2 border-terminal-green/50 pl-2"
           >
             <div className="text-terminal-dim break-all">
-              $ mail -s &quot;{subject.trim() || DEFAULT_SUBJECT}&quot; james
+              $ mail -s &quot;{subject.trim() || DEFAULT_SUBJECT}&quot; james_gray
             </div>
             <div className="text-terminal-green">✓ message composed — opening your mail client…</div>
           </motion.div>

--- a/src/components/pages/education-page.tsx
+++ b/src/components/pages/education-page.tsx
@@ -20,8 +20,8 @@ export const EducationPage: React.FC = () => {
           hash={e.hash}
           period={e.period}
           title={e.institution}
-          subtitle={e.qualification}
-          detailLine={[e.grade, ...e.details].filter(Boolean).join(" · ")}
+          subtitle={e.grade ? `${e.qualification} — ${e.grade}` : e.qualification}
+          detailLine={e.details.join(" · ")}
           tags={e.tags}
         />
       )}
@@ -31,8 +31,8 @@ export const EducationPage: React.FC = () => {
           onClose={onClose}
           command={edu ? `git show ${edu.hash}` : ""}
           title={edu?.institution ?? ""}
-          subtitle={edu?.qualification}
-          meta={edu?.grade ? `${edu.period} — ${edu.grade}` : edu?.period}
+          subtitle={edu?.grade ? `${edu.qualification} — ${edu.grade}` : edu?.qualification}
+          meta={edu?.period}
           sections={edu ? [
             ...(edu.details.length > 0 ? [{
               heading: "Details",

--- a/src/components/pages/education-page.tsx
+++ b/src/components/pages/education-page.tsx
@@ -20,7 +20,7 @@ export const EducationPage: React.FC = () => {
           hash={e.hash}
           period={e.period}
           title={e.institution}
-          subtitle={e.grade ? `${e.qualification} — ${e.grade}` : e.qualification}
+          subtitle={e.grade ? `${e.qualification}: ${e.grade}` : e.qualification}
           detailLine={e.details.join(" · ")}
           tags={e.tags}
         />
@@ -31,7 +31,7 @@ export const EducationPage: React.FC = () => {
           onClose={onClose}
           command={edu ? `git show ${edu.hash}` : ""}
           title={edu?.institution ?? ""}
-          subtitle={edu?.grade ? `${edu.qualification} — ${edu.grade}` : edu?.qualification}
+          subtitle={edu?.grade ? `${edu.qualification}: ${edu.grade}` : edu?.qualification}
           meta={edu?.period}
           sections={edu ? [
             ...(edu.details.length > 0 ? [{

--- a/src/components/pages/education-page.tsx
+++ b/src/components/pages/education-page.tsx
@@ -21,7 +21,7 @@ export const EducationPage: React.FC = () => {
           period={e.period}
           title={e.institution}
           subtitle={e.qualification}
-          detailLine={e.details.join(" · ")}
+          detailLine={[e.grade, ...e.details].filter(Boolean).join(" · ")}
           tags={e.tags}
         />
       )}

--- a/src/data/content.ts
+++ b/src/data/content.ts
@@ -79,11 +79,17 @@ export function filterContact(f: ProfileField, q: string): boolean {
   );
 }
 
+/** Single source for the grade — shown on the profile and the education timeline. */
+export const DEGREE_GRADE = "First Class (81.1%)";
+
+const DEGREE_URL = "https://warwick.ac.uk/study/undergraduate/courses/beng-computer-systems-engineering/";
+
 export const PROFILE_FIELDS: ProfileField[] = [
   { key: "JOB", value: "Quant Tech", url: "https://www.qube-rt.com/" },
   { key: "COMPANY", value: "Qube Research & Technologies", url: "https://www.qube-rt.com/" },
   { key: "UNIVERSITY", value: "University of Warwick", url: "https://warwick.ac.uk/" },
-  { key: "DEGREE", value: "BEng Computer Systems Engineering (Year in Industry)" },
+  { key: "DEGREE", value: "BEng Computer Systems Engineering (Year in Industry)", url: DEGREE_URL },
+  { key: "GRADE", value: DEGREE_GRADE },
 ];
 
 export const CONTACT_FIELDS: ProfileField[] = [
@@ -386,7 +392,7 @@ export const education: Education[] = [
     institution: "University of Warwick",
     qualification: "BEng Computer Systems Engineering (Year in Industry)",
     period: "2022 — 2026",
-    grade: "First Class (81.1%)",
+    grade: DEGREE_GRADE,
     tags: [
       { label: "Artificial Intelligence" },
       { label: "AI", visible: false },

--- a/src/data/content.ts
+++ b/src/data/content.ts
@@ -80,7 +80,7 @@ export function filterContact(f: ProfileField, q: string): boolean {
 }
 
 export const PROFILE_FIELDS: ProfileField[] = [
-  { key: "JOB", value: "Quantitative Technology Intern", url: "https://www.qube-rt.com/" },
+  { key: "JOB", value: "Quant Tech", url: "https://www.qube-rt.com/" },
   { key: "COMPANY", value: "Qube Research & Technologies", url: "https://www.qube-rt.com/" },
   { key: "UNIVERSITY", value: "University of Warwick", url: "https://warwick.ac.uk/" },
   { key: "DEGREE", value: "BEng Computer Systems Engineering (Year in Industry)" },
@@ -386,7 +386,7 @@ export const education: Education[] = [
     institution: "University of Warwick",
     qualification: "BEng Computer Systems Engineering (Year in Industry)",
     period: "2022 — 2026",
-    grade: "First Class (83.3%)",
+    grade: "First Class (81.1%)",
     tags: [
       { label: "Artificial Intelligence" },
       { label: "AI", visible: false },

--- a/src/lib/themes.ts
+++ b/src/lib/themes.ts
@@ -3,7 +3,7 @@
 
 export const THEMES = ["green", "pink", "blue", "light", "synthwave", "cyberpunk", "vaporwave"] as const;
 export type Theme = (typeof THEMES)[number];
-export const DEFAULT_THEME: Theme = THEMES[0];
+export const DEFAULT_THEME: Theme = "synthwave";
 
 /** Runtime guard: is an unknown string one of our themes? */
 export function isTheme(value: string | null): value is Theme {


### PR DESCRIPTION
Branches were 19 commits behind `origin/master` locally; this brings the accumulated `dev` work up to trunk.

## Changes

**Default theme → synthwave**
`DEFAULT_THEME` now points at `synthwave` instead of the first entry in `THEMES`. The provider and the layout's pre-hydration script both derive from that constant, so a saved theme still wins and there's no flash of the old theme on load.

**Terminal identity → `james_gray@portfolio`**
Unified across the header label, the page title, and the about page's neofetch header. The title previously said `james@` while the header said `james_gray`. The contact page's `mail` commands take a bare recipient, so they use `james_gray` without a host.

**Education / profile**
- About-page `JOB` shortened to "Quant Tech" (the experience timeline keeps the full "Quantitative Technology Intern" title).
- Warwick grade corrected to **First Class (81.1%)** and surfaced on the education timeline row — previously it was only visible inside the click-through detail modal.
- Grade now renders against the qualification (`… (Year in Industry): First Class (81.1%)`) rather than trailing the period.
- `DEGREE` links to the [Warwick course page](https://warwick.ac.uk/study/undergraduate/courses/beng-computer-systems-engineering/); new `GRADE` row on the profile.
- The grade string is a single exported constant (`DEGREE_GRADE`) shared by the profile and the timeline, so the two can't drift.

## Verification

`bun run build` passes. Each change was checked in a running dev server — theme applied pre-hydration with a saved preference still overriding it, all four identity surfaces, both grade surfaces, and the `DEGREE` href resolving with `rel="noopener noreferrer"`.

Note: `bun install` is needed if your `node_modules` predates the themes refactor — it added `clsx` and `tailwind-merge`.
