### PR TITLE
Put the verb first in the page commands

### DIFF
--- a/src/components/pages/education-page.tsx
+++ b/src/components/pages/education-page.tsx
@@ -10,7 +10,7 @@ import { pluralCount } from "@/lib/utils";
 export const EducationPage: React.FC = () => {
   return (
     <TimelineList
-      command="education log"
+      command="log education"
       items={education}
       getKey={(e) => e.id}
       filterFn={filterEducation}

--- a/src/components/pages/experience-page.tsx
+++ b/src/components/pages/experience-page.tsx
@@ -10,7 +10,7 @@ import { pluralCount } from "@/lib/utils";
 export const ExperiencePage: React.FC = () => {
   return (
     <TimelineList
-      command="experience log"
+      command="log experience"
       items={experiences}
       getKey={(e) => e.id}
       filterFn={filterExperience}

--- a/src/components/pages/projects-page.tsx
+++ b/src/components/pages/projects-page.tsx
@@ -15,7 +15,7 @@ export const ProjectsPage: React.FC = () => {
 
   return (
     <TimelineList
-      command="projects log"
+      command="ls projects"
       items={projects}
       getKey={(p) => p.dir}
       filterFn={filterProject}


### PR DESCRIPTION
Follow-up to #16, which was already merged when this commit landed.

The tab commands read verb-first now, so they look like a command taking an argument rather than a noun with a suffix:

| Tab | Before | After |
|---|---|---|
| education | `education log` | `log education` |
| experience | `experience log` | `log experience` |
| projects | `projects log` | `ls projects` |

`about james_gray` and `socials` are unchanged.

Checked in a running dev server — all three render through the typewriter as expected.