### PR TITLE
Sync the site with the CV, add missing projects, and rework the window chrome

### DIFF
--- a/.claude/skills/run-portfolio/package.json
+++ b/.claude/skills/run-portfolio/package.json
@@ -8,6 +8,6 @@
     "smoke": "node driver.mjs"
   },
   "dependencies": {
-    "playwright": "^1.61.0"
+    "playwright": "^1.62.1"
   }
 }

--- a/.claude/skills/web-code-review/SKILL.md
+++ b/.claude/skills/web-code-review/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: web-code-review
+description: Review web code for quality, accessibility, performance, and best practices. Use when the user wants a code review of their frontend/web code.
+disable-model-invocation: true
+argument-hint: [file-or-directory]
+allowed-tools: Read, Glob, Grep, Agent
+---
+
+## Web Code Review
+
+Review the specified files or recent changes for the following categories. If `$ARGUMENTS` is provided, review those specific files/directories. Otherwise, review all staged and unstaged changes via git diff.
+
+### 1. Correctness & Bugs
+- Logic errors, off-by-one, null/undefined access
+- Missing error handling at system boundaries
+- Race conditions or stale state in React components
+- Incorrect TypeScript types or unsafe casts
+
+### 2. Accessibility (a11y)
+- Missing or incorrect ARIA attributes
+- Interactive elements without keyboard support
+- Missing alt text, labels, or roles
+- Color contrast and focus indicators
+- Semantic HTML usage (e.g., `<button>` vs `<div onClick>`)
+
+### 3. Performance
+- Unnecessary re-renders (missing memoization where it matters)
+- Large bundle imports that could be tree-shaken or lazy-loaded
+- Layout thrashing or expensive DOM operations
+- Missing `key` props or unstable keys in lists
+- Unoptimised images or assets
+
+### 4. Responsive Design & CSS
+- Broken layouts at common breakpoints (mobile, tablet, desktop)
+- Hardcoded dimensions that should be relative
+- Missing responsive utilities or media queries
+- Overflow issues, scrollbar quirks, or z-index conflicts
+- Inconsistent spacing or typography
+
+### 5. Security
+- XSS via dangerouslySetInnerHTML or unescaped user input
+- Sensitive data exposed in client-side code
+- Missing rel="noopener noreferrer" on external links
+- Insecure external resource loading
+
+### 6. Component Architecture
+- Components doing too much — should be split into smaller, focused components
+- Repeated JSX that should be extracted into a reusable component
+- Business logic mixed into presentational components (separate concerns)
+- Components that take too many props — consider composition or context instead
+- Shared layout patterns not using a common wrapper component
+- God components (>150 lines) that handle multiple responsibilities
+
+### 7. React Best Practices
+- State that should be derived rather than stored separately
+- useEffect for things that should be event handlers or computed values
+- State lifted too high or not high enough in the component tree
+- Missing cleanup in useEffect (event listeners, subscriptions, timers)
+- Direct DOM manipulation instead of using refs or React state
+- Prop drilling through many levels — consider context or composition
+- "use client" directive missing where hooks or browser APIs are used, or added unnecessarily
+- Unstable references passed as props causing child re-renders (inline objects/arrays/functions in JSX)
+
+### 8. Styling & Tailwind
+- Inconsistent use of design tokens / Tailwind theme values vs hardcoded colours or sizes
+- Conflicting or redundant Tailwind classes on the same element
+- Inline styles used where Tailwind classes exist
+- Missing dark mode or theme-aware classes where the rest of the codebase uses them
+- Tailwind classes that could be simplified (e.g., `px-4 py-4` → `p-4`)
+- Layout approaches that mix different systems (grid + absolute positioning when flex alone would work)
+
+### 9. Code Quality
+- Dead code, unused imports, or redundant logic
+- Inconsistent naming or patterns vs the rest of the codebase
+- Missing or misleading TypeScript types
+
+## Output Format
+
+For each issue found, report:
+
+```
+[SEVERITY] Category — file:line
+Description of the issue.
+Suggested fix (if not obvious).
+```
+
+Severity levels: `[CRITICAL]` `[WARNING]` `[INFO]`
+
+End with a short summary: total issues by severity, and an overall assessment.

--- a/src/components/detail-modal.tsx
+++ b/src/components/detail-modal.tsx
@@ -1,7 +1,6 @@
 "use client"
 
 import React, { useEffect, useRef } from "react";
-import { ExternalLink } from "@/components/external-link";
 import { AnimatePresence, motion } from "framer-motion";
 import { Tag } from "@/data/content";
 
@@ -139,16 +138,5 @@ export function BadgeList({ items }: { items: Tag[] }) {
         </span>
       ))}
     </div>
-  );
-}
-
-export function SourceLink({ url }: { url: string }) {
-  return (
-    <ExternalLink
-      href={url}
-      className="text-terminal-cyan hover:underline t-body"
-    >
-      {url.replace("https://", "")}
-    </ExternalLink>
   );
 }

--- a/src/components/detail-modal.tsx
+++ b/src/components/detail-modal.tsx
@@ -2,6 +2,7 @@
 
 import React, { useEffect, useRef } from "react";
 import { AnimatePresence, motion } from "framer-motion";
+import { TerminalWindowBar } from "@/components/terminal-window";
 import { Tag } from "@/data/content";
 
 export interface DetailSection {
@@ -12,14 +13,13 @@ export interface DetailSection {
 interface DetailModalProps {
   open: boolean;
   onClose: () => void;
-  command: string;
   title: string;
   subtitle?: string;
   meta?: string;
   sections: DetailSection[];
 }
 
-export const DetailModal: React.FC<DetailModalProps> = ({ open, onClose, command, title, subtitle, meta, sections }) => {
+export const DetailModal: React.FC<DetailModalProps> = ({ open, onClose, title, subtitle, meta, sections }) => {
   const dialogRef = useRef<HTMLDivElement>(null);
   const closeRef = useRef<HTMLButtonElement>(null);
 
@@ -77,24 +77,15 @@ export const DetailModal: React.FC<DetailModalProps> = ({ open, onClose, command
             exit={{ opacity: 0, scale: 0.9, y: "-50%", x: "-50%" }}
             transition={{ duration: 0.15 }}
           >
-            <div className="flex items-center justify-between px-4 py-2 border-b border-terminal-border bg-terminal-bg-light sticky top-0 z-10">
-              <span className="text-terminal-dim t-body">{command}</span>
-              <button
-                ref={closeRef}
-                onClick={onClose}
-                aria-label="Close"
-                className="text-terminal-dim hover:text-terminal-green transition-colors text-lg leading-none"
-              >
-                ✕
-              </button>
-            </div>
+            <TerminalWindowBar title={title} onClose={onClose} closeRef={closeRef} />
 
             <div className="p-4 md:p-6 space-y-4">
-              <div>
-                <h2 className="text-terminal-green font-bold text-sm md:text-base">{title}</h2>
-                {subtitle && <div className="text-terminal-cyan t-body mt-1">{subtitle}</div>}
-                {meta && <div className="text-terminal-amber t-body mt-1">{meta}</div>}
-              </div>
+              {(subtitle || meta) && (
+                <div>
+                  {subtitle && <div className="text-terminal-cyan t-body">{subtitle}</div>}
+                  {meta && <div className="text-terminal-amber t-body mt-1">{meta}</div>}
+                </div>
+              )}
 
               {sections.map((section) => (
                 <div key={section.heading}>

--- a/src/components/pages/education-page.tsx
+++ b/src/components/pages/education-page.tsx
@@ -27,7 +27,6 @@ export const EducationPage: React.FC = () => {
         <DetailModal
           open={edu !== null}
           onClose={onClose}
-          command={edu ? `git show "${edu.institution}"` : ""}
           title={edu?.institution ?? ""}
           subtitle={edu?.grade ? `${edu.qualification}: ${edu.grade}` : edu?.qualification}
           meta={edu?.period}

--- a/src/components/pages/experience-page.tsx
+++ b/src/components/pages/experience-page.tsx
@@ -17,8 +17,8 @@ export const ExperiencePage: React.FC = () => {
       renderEntry={(e) => (
         <TimelineEntry
           period={e.period}
-          title={e.role}
-          subtitle={e.company}
+          title={e.company}
+          subtitle={e.role}
           detailLine={e.summary.join(" · ")}
           tags={e.tags}
         />
@@ -27,8 +27,8 @@ export const ExperiencePage: React.FC = () => {
         <DetailModal
           open={exp !== null}
           onClose={onClose}
-          title={exp?.role ?? ""}
-          subtitle={exp?.company}
+          title={exp?.company ?? ""}
+          subtitle={exp?.role}
           meta={exp?.period}
           sections={exp ? [
             {

--- a/src/components/pages/experience-page.tsx
+++ b/src/components/pages/experience-page.tsx
@@ -27,7 +27,6 @@ export const ExperiencePage: React.FC = () => {
         <DetailModal
           open={exp !== null}
           onClose={onClose}
-          command={exp ? `git show "${exp.role}"` : ""}
           title={exp?.role ?? ""}
           subtitle={exp?.company}
           meta={exp?.period}

--- a/src/components/pages/projects-page.tsx
+++ b/src/components/pages/projects-page.tsx
@@ -31,7 +31,8 @@ export const ProjectsPage: React.FC = () => {
               <RowChevron />
             </span>
           </div>
-          <div className="text-terminal-dim t-body mb-2">
+          {/* Sits in the cyan subtitle slot, matching the log timelines' second line. */}
+          <div className="text-terminal-cyan t-body mb-2">
             {p.description}
           </div>
           {/* tags resolve last */}

--- a/src/components/pages/projects-page.tsx
+++ b/src/components/pages/projects-page.tsx
@@ -27,7 +27,7 @@ export const ProjectsPage: React.FC = () => {
           </span>
           <div className="flex items-center gap-2 mb-1">
             <span className="text-terminal-green font-bold text-sm md:text-base flex items-center gap-1 group-hover:underline">
-              <MatrixText text={`${p.dir}/`} delay={index * CARD_STEP_MS + 60} />
+              <MatrixText text={p.dir} delay={index * CARD_STEP_MS + 60} />
               <RowChevron />
             </span>
           </div>

--- a/src/components/pages/projects-page.tsx
+++ b/src/components/pages/projects-page.tsx
@@ -46,7 +46,6 @@ export const ProjectsPage: React.FC = () => {
         <DetailModal
           open={project !== null}
           onClose={onClose}
-          command={project ? `cat ~/${project.dir}/README.md` : ""}
           title={project?.title ?? ""}
           subtitle={project?.description}
           sections={project ? [

--- a/src/components/pages/projects-page.tsx
+++ b/src/components/pages/projects-page.tsx
@@ -27,7 +27,7 @@ export const ProjectsPage: React.FC = () => {
           </span>
           <div className="flex items-center gap-2 mb-1">
             <span className="text-terminal-green font-bold text-sm md:text-base flex items-center gap-1 group-hover:underline">
-              <MatrixText text={p.dir} delay={index * CARD_STEP_MS + 60} />
+              <MatrixText text={p.title} delay={index * CARD_STEP_MS + 60} />
               <RowChevron />
             </span>
           </div>

--- a/src/components/pages/projects-page.tsx
+++ b/src/components/pages/projects-page.tsx
@@ -5,14 +5,12 @@ import { projects, filterProject } from "@/data/content";
 import { TimelineList } from "@/components/timeline-list";
 import { RowChevron } from "@/components/timeline-entry";
 import { MatrixText } from "@/components/matrix-text";
-import { DetailModal, BulletList, BadgeList, SourceLink } from "@/components/detail-modal";
-import { cn, pluralCount } from "@/lib/utils";
+import { DetailModal, BulletList, BadgeList } from "@/components/detail-modal";
+import { pluralCount } from "@/lib/utils";
 
 const CARD_STEP_MS = 70; // keep in step with TimelineList's per-row reveal delay
 
 export const ProjectsPage: React.FC = () => {
-  const publicCount = projects.filter(p => p.url).length;
-
   return (
     <TimelineList
       command="ls projects"
@@ -31,9 +29,6 @@ export const ProjectsPage: React.FC = () => {
             <span className="text-terminal-green font-bold text-sm md:text-base flex items-center gap-1 group-hover:underline">
               <MatrixText text={`${p.dir}/`} delay={index * CARD_STEP_MS + 60} />
               <RowChevron />
-            </span>
-            <span className={cn("ml-auto shrink-0 t-micro px-1.5 py-0.5 rounded-sm border border-terminal-border", p.url ? "text-terminal-green" : "text-terminal-red")}>
-              {p.url ? "public" : "private"}
             </span>
           </div>
           <div className="text-terminal-dim t-body mb-2">
@@ -62,14 +57,10 @@ export const ProjectsPage: React.FC = () => {
               heading: "Tags",
               content: <BadgeList items={project.tags} />,
             },
-            ...(project.url ? [{
-              heading: "Source",
-              content: <SourceLink url={project.url} />,
-            }] : []),
           ] : []}
         />
       )}
-      renderFooter={(filtered, total) => `${pluralCount(filtered, total, "items")}, ${publicCount} public`}
+      renderFooter={(filtered, total) => pluralCount(filtered, total, "items")}
     />
   );
 };

--- a/src/components/pages/socials-page.tsx
+++ b/src/components/pages/socials-page.tsx
@@ -1,8 +1,9 @@
 "use client"
 
 import React, { useCallback, useState } from "react";
-import { FiCheck, FiCopy, FiExternalLink, FiGithub, FiLinkedin, FiMail, FiX } from "react-icons/fi";
+import { FiCheck, FiCopy, FiExternalLink, FiGithub, FiLinkedin, FiMail } from "react-icons/fi";
 import { TerminalPage } from "@/components/terminal-page";
+import { TerminalWindow } from "@/components/terminal-window";
 import { ExternalLink } from "@/components/external-link";
 import { CONTACT_FIELDS, type ProfileField } from "@/data/content";
 
@@ -127,16 +128,9 @@ export const SocialsPage: React.FC = () => (
       // Centred: three short lines would otherwise sit marooned at the top of a
       // full-height terminal.
       <div className="flex h-full items-center justify-center">
-        <div className="w-full max-w-2xl overflow-hidden rounded-sm border border-terminal-border fade-rise">
-          {/* Title bar. The ✕ is window dressing, not a control — it carries no
-              button semantics and is hidden from assistive tech, so nobody is
-              invited to click something that does nothing. */}
-          <div className="flex items-baseline gap-2 border-b border-terminal-border bg-terminal-bg-light px-4 py-2 sm:px-5 md:px-6">
-            <span className="text-sm font-bold text-terminal-green md:text-base">james_gray</span>
-            <span className="t-micro text-terminal-dim">— socials</span>
-            <FiX className="ml-auto h-4 w-4 shrink-0 self-center text-terminal-dim" aria-hidden="true" />
-          </div>
-
+        {/* Same chrome as the detail modal, minus the modality. Its ✕ has nothing
+            to dismiss, so it wiggles the frame instead of doing nothing. */}
+        <TerminalWindow title="james_gray" subtitle="socials" className="w-full max-w-2xl fade-rise">
           {/* Steps down to the site's body size on phones so a full email address
               still fits on one line inside the frame. Horizontal padding matches
               the title bar, so the row icons sit under the window title. */}
@@ -146,7 +140,7 @@ export const SocialsPage: React.FC = () => (
               <SocialRow key={field.key} field={field} index={i} />
             ))}
           </div>
-        </div>
+        </TerminalWindow>
       </div>
     )}
   </TerminalPage>

--- a/src/components/terminal-window.tsx
+++ b/src/components/terminal-window.tsx
@@ -1,0 +1,86 @@
+"use client"
+
+import React from "react";
+import { FiX } from "react-icons/fi";
+import { motion, useAnimationControls, useReducedMotion } from "framer-motion";
+import { cn } from "@/lib/utils";
+
+interface TerminalWindowBarProps {
+  title: string;
+  /** Muted suffix after an em dash, e.g. "james_gray — socials". */
+  subtitle?: string;
+  onClose: () => void;
+  closeLabel?: string;
+  closeRef?: React.Ref<HTMLButtonElement>;
+}
+
+/** Title bar shared by the floating detail modal and the inline window below. */
+export function TerminalWindowBar({
+  title,
+  subtitle,
+  onClose,
+  closeLabel = "Close",
+  closeRef,
+}: TerminalWindowBarProps) {
+  return (
+    <div className="sticky top-0 z-10 flex items-baseline gap-2 border-b border-terminal-border bg-terminal-bg-light px-4 py-2 sm:px-5 md:px-6">
+      <span className="text-sm font-bold text-terminal-green md:text-base">{title}</span>
+      {subtitle && <span className="t-micro text-terminal-dim">— {subtitle}</span>}
+      <button
+        ref={closeRef}
+        type="button"
+        onClick={onClose}
+        aria-label={closeLabel}
+        className="ml-auto shrink-0 self-center text-terminal-dim transition-colors hover:text-terminal-green"
+      >
+        <FiX className="h-4 w-4" />
+      </button>
+    </div>
+  );
+}
+
+// Damped left-right shake: the window shrugs off a ✕ that has nothing to close.
+const WIGGLE = { x: [0, -6, 6, -5, 5, -3, 3, 0] };
+
+interface TerminalWindowProps {
+  title: string;
+  subtitle?: string;
+  className?: string;
+  children: React.ReactNode;
+}
+
+/**
+ * The detail modal's frame without the modal — same chrome, sits inline in the
+ * page. Its ✕ is honest window dressing: it stays clickable, but wiggles rather
+ * than pretending there is something to dismiss.
+ */
+export function TerminalWindow({ title, subtitle, className, children }: TerminalWindowProps) {
+  const controls = useAnimationControls();
+  const reduceMotion = useReducedMotion();
+
+  const shrug = () => {
+    if (reduceMotion) return;
+    controls.start({ ...WIGGLE, transition: { duration: 0.4, ease: "easeInOut" } });
+  };
+
+  // Two elements on purpose: the caller's entrance animation (`fade-rise`) is a
+  // CSS animation with `animation-fill-mode: forwards`, which outranks inline
+  // styles — on one element it would permanently pin the transform and swallow
+  // the shake. The outer div owns the entrance, the inner one owns the wiggle.
+  return (
+    <div className={className}>
+      <motion.div
+        animate={controls}
+        className="overflow-hidden rounded-sm border border-terminal-border bg-terminal-bg"
+      >
+        <TerminalWindowBar
+          title={title}
+          subtitle={subtitle}
+          onClose={shrug}
+          closeLabel="This window stays put"
+        />
+        {children}
+      </motion.div>
+    </div>
+  );
+}

--- a/src/data/content.ts
+++ b/src/data/content.ts
@@ -150,8 +150,8 @@ export const experiences: Experience[] = [
     id: "e4f5a6b",
     role: "A-Level and GCSE Tutor",
     company: "MyTutor",
-    period: "Jan 2023 — Present",
-    summary: ["Communicating complex concepts in a simple way to help A-Level and GCSE students master subject material."],
+    period: "Jan 2023 — Jun 2024",
+    summary: ["Communicated complex concepts in a simple way to help A-Level and GCSE students master subject material."],
     tags: [
       { label: "Teaching" },
       { label: "Maths" },

--- a/src/data/content.ts
+++ b/src/data/content.ts
@@ -29,7 +29,6 @@ export interface Project {
   description: string;
   tags: Tag[];
   details: string[];
-  url?: string;
 }
 
 export interface Education {
@@ -103,7 +102,7 @@ export const CONTACT_FIELDS: ProfileField[] = [
   { key: "GITHUB", value: "@expiracy", url: "https://github.com/expiracy" },
 ];
 
-export const BIO_TEXT = "Computer Systems Engineering student with industry experience in quantitative technology. Skilled in C, C++, Python, Java, TypeScript, React, and systems programming.";
+export const BIO_TEXT = "Computer Systems Engineering student with industry experience in quantitative technology. Skilled in C, C++, C#, Python, Java, TypeScript and React, across systems programming, hardware and machine learning.";
 
 export const ASCII_JAMES = `     ██╗ █████╗ ███╗   ███╗███████╗███████╗
      ██║██╔══██╗████╗ ████║██╔════╝██╔════╝
@@ -124,8 +123,8 @@ export const experiences: Experience[] = [
     id: "a1b2c3d",
     role: "Quantitative Technology Intern",
     company: "Qube Research & Technologies",
-    period: "Jun 2024 — Present",
-    summary: ["Developing deployment tooling, process management services, and LLM-based support systems."],
+    period: "Jun 2024 — Jun 2025",
+    summary: ["Developed deployment tooling, process management services, and LLM-based support systems."],
     tags: [
       { label: "C++" },
       { label: "C#" },
@@ -136,18 +135,20 @@ export const experiences: Experience[] = [
       { label: "Linux", visible: false },
       { label: "DevOps", visible: false },
       { label: "TypeScript", visible: false },
+      { label: "RAG", visible: false },
+      { label: "Infrastructure as Code", visible: false },
     ],
     details: [
-      "Improving deployments by developing a tool that automatically generates environment-specific configurations, new supporting tools that leverage these configurations, and integrating the process management service to enhance consistency and reduce manual effort",
       "Designed and implemented a C++ process management service that enables support teams to control and monitor system processes through both a UI and code, eliminating the need for manual SSH interaction",
+      "Introduced an infrastructure-as-code initiative that auto-generates environment-specific configurations and wires them into the process management service, establishing a single source of truth",
+      "Reworked and upgraded system components and the CI/CD pipeline to support C# builds and tests on the Linux environment, increasing code coverage and unblocking Linux developers",
+      "Built an LLM support assistant with a React.js frontend, using RAG over company-specific knowledge in a reasoning-and-act loop with custom tools for multi-step reasoning, context access, and output verification, improving answer accuracy and quality",
       "Developed automated tools to generate documentation and samples for multiple languages to a single reference point",
-      "Reworked and upgraded system components and the CI/CD pipeline to support C# builds and tests on the Linux environment, increasing code coverage and Linux developer capabilities",
-      "Developed an LLM-based support assistant with a React.js frontend using the ReAct framework with custom tools for multi-step reasoning, domain-specific context access, and output verification",
     ],
   },
   {
     id: "e4f5a6b",
-    role: "Tutor",
+    role: "A-Level and GCSE Tutor",
     company: "MyTutor",
     period: "Jan 2023 — Present",
     summary: ["Communicating complex concepts in a simple way to help A-Level and GCSE students master subject material."],
@@ -214,54 +215,28 @@ export const experiences: Experience[] = [
   },
 ];
 
+// Ordered to match the CV's "Key Projects" section — dissertation first, then the
+// systems work, then everything else roughly newest-first.
 export const projects: Project[] = [
   {
-    title: "FPGA Pacman",
-    dir: "fpga-pacman",
-    description: "Recreation of Pacman on a Nexys 4 FPGA using Verilog. Achieved the top score in the year.",
-    tags: [
-      { label: "Verilog" },
-      { label: "FPGA" },
-      { label: "VGA" },
-      { label: "Hardware", visible: false },
-      { label: "Digital Design", visible: false },
-      { label: "High Performance Systems", visible: false },
-    ],
-    details: [
-      "Debugged hardware signals using Verilog test benches in Vivado to verify signals and timings across different digital modules",
-      "Implemented custom VGA drivers to manage the graphics output, including frame buffer control and pixel timing generation",
-    ],
-  },
-  {
-    title: "Magnetic Electron Trap Simulation",
-    dir: "electron-trap-sim",
-    description: "Solved and visualised differential equations to model an electron within a magnetic field. Achieved 100%.",
+    title: "Efficient PPG Sleep Staging",
+    dir: "ppg-sleep-staging",
+    description: "Final-year dissertation cutting the inference cost of deep sleep-staging models on PPG signals without giving up accuracy.",
     tags: [
       { label: "Python" },
-      { label: "NumPy" },
-      { label: "SciPy" },
-      { label: "Matplotlib" },
-      { label: "Simulation", visible: false },
-      { label: "Physics", visible: false },
+      { label: "PyTorch" },
+      { label: "Mamba" },
+      { label: "Deep Learning" },
+      { label: "Machine Learning", visible: false },
+      { label: "ML", visible: false },
+      { label: "Time-Series", visible: false },
+      { label: "Signal Processing", visible: false },
+      { label: "Dissertation", visible: false },
     ],
     details: [
-      "Implemented multiprocessing to parallelise simulation code and bypass the Global Interpreter Lock (GIL) to achieve a 20x performance improvement",
-    ],
-  },
-  {
-    title: "Multithreaded Packet Sniffer",
-    dir: "packet-sniffer",
-    description: "Developed a multithreaded packet sniffer to identify domain blacklist violations, SYN attacks, and ARP cache poisoning.",
-    tags: [
-      { label: "C" },
-      { label: "Networking" },
-      { label: "Multithreading" },
-      { label: "Security", visible: false },
-      { label: "Linux", visible: false },
-    ],
-    details: [
-      "Implemented a thread-safe packet queue with pthreads to dispatch work efficiently to a thread pool, allowing the application to successfully process 1,000,000s of packets without loss",
-      "Ensured memory leak, race condition and bug free code by validating code with tools like Valgrind, Helgrind and GDB",
+      "Pinpointed the architectural bottlenecks driving inference cost in state-of-the-art PPG sleep-staging models",
+      "Designed and implemented Mamba and efficient-attention architectures in PyTorch, holding accuracy (κ = 0.74) across three clinical datasets (MESA, CFS, HOMEPAP)",
+      "Raised inference throughput 3.8x while cutting VRAM 53% and model size 57%, making deployment far more scalable",
     ],
   },
   {
@@ -278,6 +253,75 @@ export const projects: Project[] = [
     ],
     details: [
       "Leveraged AVX-256 intrinsics, OpenMP directives, and code refactoring to optimise memory data locality",
+    ],
+  },
+  {
+    title: "Mini C Compiler",
+    dir: "minic-compiler",
+    description: "A compiler for a subset of C, with a hand-written recursive-descent front end and LLVM IR code generation.",
+    tags: [
+      { label: "C++" },
+      { label: "LLVM" },
+      { label: "Compilers" },
+      { label: "Parsing", visible: false },
+      { label: "Code Generation", visible: false },
+      { label: "Compiler Design", visible: false },
+    ],
+    details: [
+      "Built a top-down recursive-descent lexer and parser in C++, generating code via LLVM IR, for a subset of C",
+      "Produced colourised, informative error diagnostics more detailed than mainstream C compilers",
+    ],
+  },
+  {
+    title: "Multithreaded Packet Sniffer",
+    dir: "packet-sniffer",
+    description: "Developed a multithreaded packet sniffer to identify domain blacklist violations, SYN attacks, and ARP cache poisoning.",
+    tags: [
+      { label: "C" },
+      { label: "Networking" },
+      { label: "Multithreading" },
+      { label: "Security", visible: false },
+      { label: "Linux", visible: false },
+    ],
+    details: [
+      "Implemented a thread-safe packet queue with pthreads feeding a thread pool, processing 1,000,000s of packets without loss",
+      "Validated the program was free of memory leaks and race conditions with Valgrind, Helgrind and GDB",
+    ],
+  },
+  {
+    title: "FPGA Pacman",
+    dir: "fpga-pacman",
+    description: "Recreation of Pacman on a Nexys 4 FPGA using Verilog. Achieved the top score in the year.",
+    tags: [
+      { label: "Verilog" },
+      { label: "FPGA" },
+      { label: "VGA" },
+      { label: "Vivado", visible: false },
+      { label: "BRAM", visible: false },
+      { label: "Hardware", visible: false },
+      { label: "Digital Design", visible: false },
+      { label: "High Performance Systems", visible: false },
+    ],
+    details: [
+      "Implemented Pacman's game logic — movement, collisions and scoring — as hardware state machines, taking the top score in the year",
+      "Rendered the game from sprites held in on-chip BRAM, with custom frame-drawing logic and a real-time VGA driver built in hardware",
+      "Debugged hardware signals using Verilog test benches in Vivado to verify signals and timings across different digital modules",
+    ],
+  },
+  {
+    title: "Magnetic Electron Trap Simulation",
+    dir: "electron-trap-sim",
+    description: "Solved and visualised differential equations to model an electron within a magnetic field. Achieved 100%.",
+    tags: [
+      { label: "Python" },
+      { label: "NumPy" },
+      { label: "SciPy" },
+      { label: "Matplotlib" },
+      { label: "Simulation", visible: false },
+      { label: "Physics", visible: false },
+    ],
+    details: [
+      "Implemented multiprocessing to parallelise simulation code and bypass the Global Interpreter Lock (GIL) to achieve a 20x performance improvement",
     ],
   },
   {
@@ -299,7 +343,6 @@ export const projects: Project[] = [
     title: "Resistor Image Scanner",
     dir: "resistor-scanner",
     description: "Web app using image processing techniques to identify resistor values from images. Achieved 100%.",
-    url: "https://github.com/expiracy/resistor",
     tags: [
       { label: "Python" },
       { label: "OpenCV" },
@@ -317,7 +360,6 @@ export const projects: Project[] = [
     title: "Discord Drive",
     dir: "discord-drive",
     description: "A proof of concept full-stack web app allowing users to store files via Discord and browse them in a browser.",
-    url: "https://github.com/expiracy/discord-drive",
     tags: [
       { label: "Python" },
       { label: "Quart" },
@@ -366,7 +408,6 @@ export const projects: Project[] = [
     title: "Simple Circuit Solver",
     dir: "circuit-solver",
     description: "Algorithms that solve simple circuits consisting of only Ohmic components.",
-    url: "https://github.com/expiracy/circuit-calculator",
     tags: [
       { label: "Python" },
       { label: "Graphs" },
@@ -389,6 +430,88 @@ export const projects: Project[] = [
       "Implemented asynchronous handling for user interactions to improve system responsiveness",
     ],
   },
+  {
+    title: "search++",
+    dir: "search-plus-plus",
+    description: "A VS Code extension bringing JetBrains-style search everywhere — files, folders, text, symbols and commands behind one shortcut.",
+    tags: [
+      { label: "TypeScript" },
+      { label: "VS Code" },
+      { label: "ripgrep" },
+      { label: "Extension", visible: false },
+      { label: "Developer Tools", visible: false },
+    ],
+    details: [
+      "Unified filename, folder, ripgrep-backed text, language-server symbol and command search behind a single keyboard-driven modal",
+    ],
+  },
+  {
+    title: "Sign Language Detector",
+    dir: "sign-language-detector",
+    description: "Webcam ASL fingerspelling detector in MATLAB, with the surrounding tooling to collect datasets, train networks and score them.",
+    tags: [
+      { label: "MATLAB" },
+      { label: "CNN" },
+      { label: "Computer Vision" },
+      { label: "Deep Learning" },
+      { label: "Machine Learning", visible: false },
+      { label: "ML", visible: false },
+    ],
+    details: [
+      "Trained and compared ResNet-18/50/101 and GoogLeNet backbones, scoring each on accuracy, precision, recall, F1 and confusion matrices",
+      "Built the dataset pipeline around the model: webcam image and video capture tools, per-letter timestamping, and a train/test split utility",
+    ],
+  },
+  {
+    title: "Connect-N Minimax AI",
+    dir: "connect-n-minimax",
+    description: "A minimax bot player for generalised Connect-N, benchmarked against a random-move opponent.",
+    tags: [
+      { label: "Python" },
+      { label: "Minimax" },
+      { label: "Game AI" },
+      { label: "AI", visible: false },
+      { label: "Algorithms", visible: false },
+    ],
+    details: [],
+  },
+  {
+    title: "Maze Solver",
+    dir: "maze-solver",
+    description: "Search algorithms that explore an unknown maze and route a robot to the exit.",
+    tags: [
+      { label: "Java" },
+      { label: "Search Algorithms" },
+      { label: "Graphs", visible: false },
+      { label: "Pathfinding", visible: false },
+    ],
+    details: [],
+  },
+  {
+    title: "Line-Following Buggy",
+    dir: "line-buggy",
+    description: "Embedded C firmware for a buggy that tracks a line using reflectance sensor feedback.",
+    tags: [
+      { label: "C" },
+      { label: "Embedded" },
+      { label: "Microcontroller" },
+      { label: "Sensors", visible: false },
+      { label: "Control", visible: false },
+    ],
+    details: [],
+  },
+  {
+    title: "Self-Balancing Robot",
+    dir: "balancing-robot",
+    description: "Modelled and tuned the control loop for a self-balancing robot in Simulink.",
+    tags: [
+      { label: "Simulink" },
+      { label: "MATLAB" },
+      { label: "Control Systems" },
+      { label: "Modelling", visible: false },
+    ],
+    details: [],
+  },
 ];
 
 export const education: Education[] = [
@@ -402,23 +525,30 @@ export const education: Education[] = [
       { label: "Artificial Intelligence" },
       { label: "AI", visible: false },
       { label: "Machine Learning" },
-      { label: "Neural Computing" },
+      // Dropped from the CV's Key Concepts line for space — kept searchable here.
+      { label: "Neural Computing", visible: false },
       { label: "Compiler Design" },
       { label: "Data Structures" },
       { label: "Operating Systems" },
       { label: "Networking" },
       { label: "FPGAs" },
+      { label: "Databases" },
+      { label: "Signal Processing" },
       { label: "C", visible: false },
       { label: "C++", visible: false },
       { label: "Python", visible: false },
       { label: "Java", visible: false },
       { label: "Verilog", visible: false },
+      { label: "SoCs", visible: false },
+      { label: "Analogue Electronic Design", visible: false },
+      { label: "Mathematics", visible: false },
       { label: "Software Engineering", visible: false },
       { label: "Computer Architecture", visible: false },
       { label: "Data Analytics", visible: false },
     ],
     details: [
-      "Award for Exceptional Performance (2nd Year)",
+      "Year in Industry at Qube Research & Technologies",
+      "Exceptional Achievement in Second Year",
     ],
   },
   {

--- a/src/data/content.ts
+++ b/src/data/content.ts
@@ -518,7 +518,7 @@ export const education: Education[] = [
   {
     id: "c4d5e6f",
     institution: "University of Warwick",
-    qualification: "BEng Computer Systems Engineering (Year in Industry)",
+    qualification: "BEng Computer Systems Engineering (Year in Industry at QRT)",
     period: "2022 — 2026",
     grade: DEGREE_GRADE,
     tags: [
@@ -547,8 +547,7 @@ export const education: Education[] = [
       { label: "Data Analytics", visible: false },
     ],
     details: [
-      "Year in Industry at Qube Research & Technologies",
-      "Exceptional Achievement in Second Year",
+      "Award: Exceptional Achievement in Second Year",
     ],
   },
   {
@@ -564,7 +563,7 @@ export const education: Education[] = [
     ],
     details: [
       "100% achieved in Computer Science Coursework",
-      "Received Computer Science Award",
+      "Award: Computer Science Award",
     ],
   },
   {


### PR DESCRIPTION
Brings `dev` up to date with the CV and reworks the shared window chrome.

## CV sync

The `cv` submodule was pinned 8 commits behind its `master`. It is now at the tip, and the site's content has been reconciled against it:

- **8 projects added** — the PPG sleep-staging dissertation (now the lead entry, matching the CV), Mini C Compiler, search++, Sign Language Detector, Connect-N Minimax, Maze Solver, Line-Following Buggy, Self-Balancing Robot.
- Projects reordered to the CV's Key Projects order; FPGA Pacman rewritten to lead with hardware state machines and BRAM sprite rendering.
- Qube entry adopts the CV's newer framing (infrastructure-as-code, RAG) and its closed `Jun 2024 — Jun 2025` range; MyTutor closed at `Jun 2024`. Both moved from present to past tense to match.
- Education mirrors the CV's layout: QRT folded into the degree title, awards as `Award: …` detail lines, module tags aligned with Key Concepts.

Corrections applied to the CV itself in the submodule: Reading School dates, both awards moved to the institution that granted them, pipe separators in entry headings, skills split into Languages and Technologies. The CV stays one page throughout.

## UI

- **Source links removed** from all projects, along with the derived public/private badge and the `N public` footer count — with no URLs the badge would have labelled six genuinely public repos "private".
- **Project cards** show full names rather than directory slugs, with the description promoted to the cyan subtitle colour used by the log timelines.
- **Window chrome extracted** to `terminal-window.tsx`. The detail modal is now titled by name rather than a `cat`/`git show` command line, and the socials page reuses the same frame instead of a hand-rolled copy. Its ✕ wiggles rather than pretending to dismiss anything.
- **Experience entries** lead with the company, role as subtitle — matching education, which already led with the institution.

Also included, already on `dev` before this work: the socials tab rework, alpha-capable colour tokens, and the preview server port fallback.

## Verification

`tsc --noEmit`, `next lint` and `next build` clean. Every change checked against the static export in a browser rather than the dev server, which freezes framer entrance animations.
