### PR TITLE
Finish the CV sync and adopt portfolio-first content rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ next-env.d.ts
 # editors
 .idea/
 .vscode/
+
+# claude code machine-local settings
+.claude/settings.local.json

--- a/src/data/content.ts
+++ b/src/data/content.ts
@@ -92,7 +92,7 @@ export const PROFILE_FIELDS: ProfileField[] = [
   { key: "JOB", value: "Incoming Quant Tech", highlight: true },
   { key: "COMPANY", value: "Qube Research & Technologies", url: "https://www.qube-rt.com/", child: true },
   { key: "UNIVERSITY", value: "University of Warwick", url: "https://warwick.ac.uk/" },
-  { key: "DEGREE", value: "BEng Computer Systems Engineering (Year in Industry)", child: true, highlight: true },
+  { key: "DEGREE", value: "BEng Computer Systems Engineering (Year in Industry at QRT)", child: true, highlight: true },
   { key: "GRADE", value: DEGREE_GRADE, child: true, highlight: true },
 ];
 


### PR DESCRIPTION
Follow-up to #18. Small, three commits.

## Content

The About page's profile block still read `BEng Computer Systems Engineering (Year in Industry)` while the education tab and the CV both read `(Year in Industry at QRT)`. That was the last remaining contradiction between the site and the CV — the profile block now matches.

## Policy

The `cv` submodule bump carries two new committed skills, which change how the two repos relate going forward:

- **`cv-branching`** — the default branch holds the central, general-purpose CV and takes changes directly. Every other branch is one CV tailored to a single application, named `<company>-<role>`. Tailored branches may pull from the default branch but must never merge back, since that would bend the general CV toward one employer.
- **The portfolio is now the source of truth.** New facts land in `src/data/content.ts` first and the CV is adapted down from it — condensing a full record onto one page is redoable, reconstructing the record from the page is not. One carve-out: the CV's Languages/Technologies block has no counterpart in the site data, so the CV owns it until a skills field exists.
- **`cv-bullet-writer`** gained the pipe-separator rule for entry headings.

## Housekeeping

`.claude/settings.local.json` is now gitignored. It is per-machine config and hardcodes an absolute path, so it does not belong in the repo — the committed `.claude/settings.json` is the place for anything shared.
